### PR TITLE
增加多数据源链式事务支持

### DIFF
--- a/ruoyi-framework/pom.xml
+++ b/ruoyi-framework/pom.xml
@@ -8,91 +8,111 @@
         <version>4.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-	
+
     <artifactId>ruoyi-framework</artifactId>
-	
-	<description>
-	    framework框架核心
-	</description>
-    
+
+    <description>
+        framework框架核心
+    </description>
+
     <dependencies>
 
         <!-- SpringBoot Web容器 -->
-	     <dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
         <!-- SpringBoot 拦截器 -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-aop</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
 
-		<!--阿里数据库连接池 -->
-		<dependency>
+        <!--阿里数据库连接池 -->
+        <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid-spring-boot-starter</artifactId>
         </dependency>
-		
-		<!--验证码 -->
-		<dependency>
-			<groupId>com.github.penggle</groupId>
-			<artifactId>kaptcha</artifactId>
-			<exclusions>
-				<exclusion>
-					<artifactId>javax.servlet-api</artifactId>
-					<groupId>javax.servlet</groupId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 
-		<!-- Shiro使用Spring框架 -->
-		<dependency>
-			<groupId>org.apache.shiro</groupId>
-			<artifactId>shiro-spring</artifactId>
-		</dependency>
+        <!--验证码 -->
+        <dependency>
+            <groupId>com.github.penggle</groupId>
+            <artifactId>kaptcha</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>javax.servlet-api</artifactId>
+                    <groupId>javax.servlet</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-		<!-- Shiro使用EhCache缓存框架 -->
-		<dependency>
-			<groupId>org.apache.shiro</groupId>
-			<artifactId>shiro-ehcache</artifactId>
-		</dependency>
-		
-		<!-- thymeleaf模板引擎和shiro框架的整合 -->
-		<dependency>
-			<groupId>com.github.theborakompanioni</groupId>
-			<artifactId>thymeleaf-extras-shiro</artifactId>
-		</dependency>
+        <!-- Shiro使用Spring框架 -->
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-spring</artifactId>
+        </dependency>
 
-		<!-- 解析客户端操作系统、浏览器等 -->
-		<dependency>
-			<groupId>eu.bitwalker</groupId>
-			<artifactId>UserAgentUtils</artifactId>
-		</dependency>
+        <!-- Shiro使用EhCache缓存框架 -->
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-ehcache</artifactId>
+        </dependency>
+
+        <!-- thymeleaf模板引擎和shiro框架的整合 -->
+        <dependency>
+            <groupId>com.github.theborakompanioni</groupId>
+            <artifactId>thymeleaf-extras-shiro</artifactId>
+        </dependency>
+
+        <!-- 解析客户端操作系统、浏览器等 -->
+        <dependency>
+            <groupId>eu.bitwalker</groupId>
+            <artifactId>UserAgentUtils</artifactId>
+        </dependency>
 
         <!-- 系统模块-->
         <dependency>
             <groupId>com.ruoyi</groupId>
             <artifactId>ruoyi-system</artifactId>
         </dependency>
-		
-		<!-- 获取系统信息 -->
-		<dependency>
-			<groupId>com.github.oshi</groupId>
-			<artifactId>oshi-core</artifactId>
-		</dependency>
-		
-		<dependency>
-			<groupId>net.java.dev.jna</groupId>
-			<artifactId>jna</artifactId>
-		</dependency>
-		
-		<dependency>
-			<groupId>net.java.dev.jna</groupId>
-			<artifactId>jna-platform</artifactId>
-		</dependency>
+
+        <!-- 获取系统信息 -->
+        <dependency>
+            <groupId>com.github.oshi</groupId>
+            <artifactId>oshi-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+        </dependency>
+
+        <!--spring-data-commons，主要用于事务链调用-->
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-beans</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
     </dependencies>
-    
+
 </project>

--- a/ruoyi-framework/src/main/java/com/ruoyi/framework/config/CustomSqlSessionTemplate.java
+++ b/ruoyi-framework/src/main/java/com/ruoyi/framework/config/CustomSqlSessionTemplate.java
@@ -1,0 +1,311 @@
+package com.ruoyi.framework.config;
+
+import com.ruoyi.common.config.datasource.DynamicDataSourceContextHolder;
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.executor.BatchResult;
+import org.apache.ibatis.reflection.ExceptionUtil;
+import org.apache.ibatis.session.*;
+import org.mybatis.spring.MyBatisExceptionTranslator;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.mybatis.spring.SqlSessionUtils;
+import org.springframework.dao.support.PersistenceExceptionTranslator;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.reflect.Proxy.newProxyInstance;
+
+/**
+ * 自定义SqlSessionTemplate，用于动态选择主从sqlSessionFactory
+ */
+public class CustomSqlSessionTemplate extends SqlSessionTemplate {
+    private final SqlSessionFactory sqlSessionFactory;
+    private final ExecutorType executorType;
+    private final SqlSession sqlSessionProxy;
+    private final PersistenceExceptionTranslator exceptionTranslator;
+
+    private Map<Object, SqlSessionFactory> targetSqlSessionFactories;
+    private SqlSessionFactory defaultTargetSqlSessionFactory;
+
+    public void setTargetSqlSessionFactories(Map<Object, SqlSessionFactory> targetSqlSessionFactories) {
+        this.targetSqlSessionFactories = targetSqlSessionFactories;
+    }
+
+    public void setDefaultTargetSqlSessionFactory(SqlSessionFactory defaultTargetSqlSessionFactory) {
+        this.defaultTargetSqlSessionFactory = defaultTargetSqlSessionFactory;
+    }
+
+    public CustomSqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
+        this(sqlSessionFactory, sqlSessionFactory.getConfiguration().getDefaultExecutorType());
+    }
+
+    public CustomSqlSessionTemplate(SqlSessionFactory sqlSessionFactory, ExecutorType executorType) {
+        this(sqlSessionFactory, executorType, new MyBatisExceptionTranslator(sqlSessionFactory.getConfiguration()
+                .getEnvironment().getDataSource(), true));
+    }
+
+    public CustomSqlSessionTemplate(SqlSessionFactory sqlSessionFactory, ExecutorType executorType,
+                                    PersistenceExceptionTranslator exceptionTranslator) {
+
+        super(sqlSessionFactory, executorType, exceptionTranslator);
+
+        this.sqlSessionFactory = sqlSessionFactory;
+        this.executorType = executorType;
+        this.exceptionTranslator = exceptionTranslator;
+
+        this.sqlSessionProxy = (SqlSession) newProxyInstance(
+                SqlSessionFactory.class.getClassLoader(),
+                new Class[]{SqlSession.class},
+                new SqlSessionInterceptor());
+
+        this.defaultTargetSqlSessionFactory = sqlSessionFactory;
+    }
+
+    @Override
+    public SqlSessionFactory getSqlSessionFactory() {
+        //当前数据源
+        String currentDsName = DynamicDataSourceContextHolder.getDataSourceType();
+        SqlSessionFactory targetSqlSessionFactory = targetSqlSessionFactories.get(currentDsName);
+        if (targetSqlSessionFactory != null) {
+            return targetSqlSessionFactory;
+        } else if (defaultTargetSqlSessionFactory != null) {
+            return defaultTargetSqlSessionFactory;
+        }
+        return this.sqlSessionFactory;
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return this.getSqlSessionFactory().getConfiguration();
+    }
+
+    public ExecutorType getExecutorType() {
+        return this.executorType;
+    }
+
+    public PersistenceExceptionTranslator getPersistenceExceptionTranslator() {
+        return this.exceptionTranslator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <T> T selectOne(String statement) {
+        return this.sqlSessionProxy.<T>selectOne(statement);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <T> T selectOne(String statement, Object parameter) {
+        return this.sqlSessionProxy.<T>selectOne(statement, parameter);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <K, V> Map<K, V> selectMap(String statement, String mapKey) {
+        return this.sqlSessionProxy.<K, V>selectMap(statement, mapKey);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey) {
+        return this.sqlSessionProxy.<K, V>selectMap(statement, parameter, mapKey);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, RowBounds rowBounds) {
+        return this.sqlSessionProxy.<K, V>selectMap(statement, parameter, mapKey, rowBounds);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <E> List<E> selectList(String statement) {
+        return this.sqlSessionProxy.<E>selectList(statement);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <E> List<E> selectList(String statement, Object parameter) {
+        return this.sqlSessionProxy.<E>selectList(statement, parameter);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <E> List<E> selectList(String statement, Object parameter, RowBounds rowBounds) {
+        return this.sqlSessionProxy.<E>selectList(statement, parameter, rowBounds);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void select(String statement, ResultHandler handler) {
+        this.sqlSessionProxy.select(statement, handler);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void select(String statement, Object parameter, ResultHandler handler) {
+        this.sqlSessionProxy.select(statement, parameter, handler);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void select(String statement, Object parameter, RowBounds rowBounds, ResultHandler handler) {
+        this.sqlSessionProxy.select(statement, parameter, rowBounds, handler);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int insert(String statement) {
+        return this.sqlSessionProxy.insert(statement);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int insert(String statement, Object parameter) {
+        return this.sqlSessionProxy.insert(statement, parameter);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int update(String statement) {
+        return this.sqlSessionProxy.update(statement);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int update(String statement, Object parameter) {
+        return this.sqlSessionProxy.update(statement, parameter);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int delete(String statement) {
+        return this.sqlSessionProxy.delete(statement);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int delete(String statement, Object parameter) {
+        return this.sqlSessionProxy.delete(statement, parameter);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <T> T getMapper(Class<T> type) {
+        return getConfiguration().getMapper(type, this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void commit() {
+        throw new UnsupportedOperationException("Manual commit is not allowed over a Spring managed SqlSession");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void commit(boolean force) {
+        throw new UnsupportedOperationException("Manual commit is not allowed over a Spring managed SqlSession");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void rollback() {
+        throw new UnsupportedOperationException("Manual rollback is not allowed over a Spring managed SqlSession");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void rollback(boolean force) {
+        throw new UnsupportedOperationException("Manual rollback is not allowed over a Spring managed SqlSession");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void close() {
+        throw new UnsupportedOperationException("Manual close is not allowed over a Spring managed SqlSession");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clearCache() {
+        this.sqlSessionProxy.clearCache();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Connection getConnection() {
+        return this.sqlSessionProxy.getConnection();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 1.0.2
+     */
+    public List<BatchResult> flushStatements() {
+        return this.sqlSessionProxy.flushStatements();
+    }
+
+    /**
+     * Proxy needed to route MyBatis method calls to the proper SqlSession got from Spring's Transaction Manager It also
+     * unwraps exceptions thrown by {@code Method#invoke(Object, Object...)} to pass a {@code PersistenceException} to
+     * the {@code PersistenceExceptionTranslator}.
+     */
+    private class SqlSessionInterceptor implements InvocationHandler {
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            SqlSessionFactory sqlSessionFactory = CustomSqlSessionTemplate.this.getSqlSessionFactory();
+            final SqlSession sqlSession = SqlSessionUtils.getSqlSession(
+                    sqlSessionFactory, CustomSqlSessionTemplate.this.executorType, CustomSqlSessionTemplate.this.exceptionTranslator);
+            try {
+                Object result = method.invoke(sqlSession, args);
+                if (!SqlSessionUtils.isSqlSessionTransactional(sqlSession, CustomSqlSessionTemplate.this.getSqlSessionFactory())) {
+                    // force commit even on non-dirty sessions because some databases require
+                    // a commit/rollback before calling close()
+                    sqlSession.commit(true);
+                }
+                return result;
+            } catch (Throwable t) {
+                Throwable unwrapped = ExceptionUtil.unwrapThrowable(t);
+                if (CustomSqlSessionTemplate.this.exceptionTranslator != null && unwrapped instanceof PersistenceException) {
+                    Throwable translated = CustomSqlSessionTemplate.this.exceptionTranslator
+                            .translateExceptionIfPossible((PersistenceException) unwrapped);
+                    if (translated != null) {
+                        unwrapped = translated;
+                    }
+                }
+                throw unwrapped;
+            } finally {
+                SqlSessionUtils.closeSqlSession(sqlSession, CustomSqlSessionTemplate.this.getSqlSessionFactory());
+            }
+        }
+    }
+
+}

--- a/ruoyi-framework/src/main/java/com/ruoyi/framework/config/MyBatisConfig.java
+++ b/ruoyi-framework/src/main/java/com/ruoyi/framework/config/MyBatisConfig.java
@@ -1,17 +1,20 @@
 package com.ruoyi.framework.config;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 import javax.sql.DataSource;
+
+import com.ruoyi.common.enums.DataSourceType;
 import org.apache.ibatis.io.VFS;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.boot.autoconfigure.SpringBootVFS;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
@@ -24,80 +27,114 @@ import org.springframework.util.ClassUtils;
 
 /**
  * Mybatis支持*匹配扫描包
- * 
+ *
  * @author ruoyi
  */
 @Configuration
-public class MyBatisConfig
-{
+public class MyBatisConfig {
     @Autowired
     private Environment env;
 
     static final String DEFAULT_RESOURCE_PATTERN = "**/*.class";
 
-    public static String setTypeAliasesPackage(String typeAliasesPackage)
-    {
+    public static String setTypeAliasesPackage(String typeAliasesPackage) {
         ResourcePatternResolver resolver = (ResourcePatternResolver) new PathMatchingResourcePatternResolver();
         MetadataReaderFactory metadataReaderFactory = new CachingMetadataReaderFactory(resolver);
         List<String> allResult = new ArrayList<String>();
-        try
-        {
-            for (String aliasesPackage : typeAliasesPackage.split(","))
-            {
+        try {
+            for (String aliasesPackage : typeAliasesPackage.split(",")) {
                 List<String> result = new ArrayList<String>();
                 aliasesPackage = ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX
                         + ClassUtils.convertClassNameToResourcePath(aliasesPackage.trim()) + "/" + DEFAULT_RESOURCE_PATTERN;
                 Resource[] resources = resolver.getResources(aliasesPackage);
-                if (resources != null && resources.length > 0)
-                {
+                if (resources != null && resources.length > 0) {
                     MetadataReader metadataReader = null;
-                    for (Resource resource : resources)
-                    {
-                        if (resource.isReadable())
-                        {
+                    for (Resource resource : resources) {
+                        if (resource.isReadable()) {
                             metadataReader = metadataReaderFactory.getMetadataReader(resource);
-                            try
-                            {
+                            try {
                                 result.add(Class.forName(metadataReader.getClassMetadata().getClassName()).getPackage().getName());
-                            }
-                            catch (ClassNotFoundException e)
-                            {
+                            } catch (ClassNotFoundException e) {
                                 e.printStackTrace();
                             }
                         }
                     }
                 }
-                if (result.size() > 0)
-                {
+                if (result.size() > 0) {
                     HashSet<String> hashResult = new HashSet<String>(result);
                     allResult.addAll(hashResult);
                 }
             }
-            if (allResult.size() > 0)
-            {
+            if (allResult.size() > 0) {
                 typeAliasesPackage = String.join(",", (String[]) allResult.toArray(new String[0]));
-            }
-            else
-            {
+            } else {
                 throw new RuntimeException("mybatis typeAliasesPackage 路径扫描错误,参数typeAliasesPackage:" + typeAliasesPackage + "未找到任何包");
             }
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             e.printStackTrace();
         }
         return typeAliasesPackage;
     }
 
-    @Bean
-    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception
-    {
+    /**
+     * 主数据库的SqlSessionFactory（原功能无法多数据源事务，所以需要区分两个）
+     *
+     * @param masterDataSource
+     * @return
+     * @throws Exception
+     */
+    @Primary
+    @Bean(name = "masterSqlSessionFactory")
+    public SqlSessionFactory masterSqlSessionFactory(@Qualifier("masterDataSource") DataSource masterDataSource) throws Exception {
+        return createSqlSessionFactory(masterDataSource);
+    }
+
+    /**
+     * 从数据库的SqlSessionFactory
+     *
+     * @param slaveDataSource
+     * @return
+     * @throws Exception
+     */
+    @Bean(name = "slaveSqlSessionFactory")
+    @ConditionalOnProperty(prefix = "spring.datasource.druid.slave", name = "enabled", havingValue = "true")
+    public SqlSessionFactory slaveSqlSessionFactory(@Qualifier("slaveDataSource") DataSource slaveDataSource) throws Exception {
+        return createSqlSessionFactory(slaveDataSource);
+    }
+
+    /**
+     * sqlSessionTemplate用于将sqlSessionFactory存储起来并根据注解动态获取
+     * 还有一种方法是直接从目录上分割主从，然后两个@MapperScan中指定主从对应的basePackage和sqlSessionFactory，但这样的话@DataSource注解就没什么用了，因为已经从目录上确定哪些方法属于主、哪些是从了，丢失了灵活性，但也更直观
+     *
+     * @param masterSqlSessionFactory
+     * @param slaveSqlSessionFactory
+     * @return
+     */
+    @Bean(name = "sqlSessionTemplate")
+    @ConditionalOnProperty(prefix = "spring.datasource.druid.slave", name = "enabled", havingValue = "true")
+    public CustomSqlSessionTemplate sqlSessionTemplate(@Qualifier("masterSqlSessionFactory") SqlSessionFactory masterSqlSessionFactory, @Qualifier("slaveSqlSessionFactory") SqlSessionFactory slaveSqlSessionFactory) {
+        Map<Object, SqlSessionFactory> sqlSessionFactoryMap = new HashMap<>();
+        sqlSessionFactoryMap.put(DataSourceType.MASTER.name(), masterSqlSessionFactory);
+        sqlSessionFactoryMap.put(DataSourceType.SLAVE.name(), slaveSqlSessionFactory);
+        CustomSqlSessionTemplate customSqlSessionTemplate = new CustomSqlSessionTemplate(masterSqlSessionFactory);
+        customSqlSessionTemplate.setTargetSqlSessionFactories(sqlSessionFactoryMap);
+        customSqlSessionTemplate.setDefaultTargetSqlSessionFactory(masterSqlSessionFactory);
+        return customSqlSessionTemplate;
+    }
+
+    /**
+     * 通用创建sqlSessionFactiory方法
+     *
+     * @param dataSource
+     * @return
+     * @throws Exception
+     */
+    private SqlSessionFactory createSqlSessionFactory(DataSource dataSource) throws Exception {
         String typeAliasesPackage = env.getProperty("mybatis.typeAliasesPackage");
-        String mapperLocations = env.getProperty("mybatis.mapperLocations");
         String configLocation = env.getProperty("mybatis.configLocation");
+        String mapperLocations = env.getProperty("mybatis.mapperLocations");
         typeAliasesPackage = setTypeAliasesPackage(typeAliasesPackage);
         VFS.addImplClass(SpringBootVFS.class);
-
         final SqlSessionFactoryBean sessionFactory = new SqlSessionFactoryBean();
         sessionFactory.setDataSource(dataSource);
         sessionFactory.setTypeAliasesPackage(typeAliasesPackage);


### PR DESCRIPTION
目前多数据源时使用`@Transactional`时无法切换数据源，所以参考网上的实现来修改了：
- 主要是创建多个`sqlSessionFactory`，然后声明自定义的`SqlSessionTemplate`的bean，在获取`getSqlSessionFactory`方法时动态的获取对应的`sqlSessionFactory`。
- 没有用XA分布式事务，而是用链式事务`ChainedTransactionManager `，来实现多个事务统一提交。

参考：
- [SpringBoot+Mybatis配置多数据源及事务方案](https://juejin.im/post/5eba38aa6fb9a043777c9b3a)
- [Spring事务管理（二）分布式事务管理之JTA与链式事务](https://zhuanlan.zhihu.com/p/57805893)