### PR TITLE
feat: 修改ruoyi-admin pom以方便第三方通过依赖方式进行功能扩展

### DIFF
--- a/ruoyi-admin/pom.xml
+++ b/ruoyi-admin/pom.xml
@@ -72,30 +72,15 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.1.1.RELEASE</version>
-                <configuration>
-                    <fork>true</fork> <!-- 如果没有该配置，devtools不会生效 -->
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>   
-                <groupId>org.apache.maven.plugins</groupId>   
-                <artifactId>maven-war-plugin</artifactId>   
-                <version>3.0.0</version>   
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.0.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <warName>${project.artifactId}</warName>
-                </configuration>   
-            </plugin>   
-            <!-- YUI Compressor (CSS/JS压缩) 
+                </configuration>
+            </plugin>
+            <!-- YUI Compressor (CSS/JS压缩)
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>yuicompressor-maven-plugin</artifactId>
@@ -130,5 +115,30 @@
         </plugins>
         <finalName>${project.artifactId}</finalName>
     </build>
-
+    <profiles>
+      <profile>
+        <id>fatjar</id>
+        <activation><activeByDefault>true</activeByDefault></activation>
+        <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.1.1.RELEASE</version>
+                <configuration>
+                    <fork>true</fork> <!-- 如果没有该配置，devtools不会生效 -->
+                    <classifier>fatjar</classifier>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            </plugins>
+            </build>
+      </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
原来fatjar类库改加-fat后缀, 打包到本地maven缓存仓库时如不需要fatjar可加-P!fatjar 即: `mvn install -P!fatjar`

默认ruoyi-admin jar不再包括依赖类库，用于第三方扩展时依赖。
这种方式第三升级ruoyi版本只用修改pom的对应依赖版本即可

```
@SpringBootApplication(scanBasePackages = { "com.ruoyi" }, exclude = { DataSourceAutoConfiguration.class })
public class CustomRuoyiApplication {

  public static void main(String[] args) throws Exception {
    SpringApplication.run(CustomRuoyiApplication.class, args);
  }
}
```

如第三方应用不想加载RuoYiApplication/RuoYiServletInitializer可修改scanBasePackages,只加具体的sub package ie:
```
@SpringBootApplication(scanBasePackages = { "com.ruoyi.common","com.ruoyi.framework",
        "com.ruoyi.system", "com.ruoyi.web", "com.ruoyi.generator", "com.ruoyi.quartz"" }, exclude = { DataSourceAutoConfiguration.class })
```