### PR TITLE
页面新增用户备注输入最大长度时,后端无法保存, remark长度过短

### DIFF
--- a/sql/ry_20230223.sql
+++ b/sql/ry_20230223.sql
@@ -60,7 +60,7 @@ create table sys_user (
   create_time       datetime                                   comment '创建时间',
   update_by         varchar(64)     default ''                 comment '更新者',
   update_time       datetime                                   comment '更新时间',
-  remark            varchar(500)    default null               comment '备注',
+  remark            text                                       comment '备注',
   primary key (user_id)
 ) engine=innodb auto_increment=100 comment = '用户信息表';
 


### PR DESCRIPTION
在用大佬系统，做接口自动测试的时候，发现的。职业病，特提个pr