### PR TITLE
Add empty check before call "iterator().next()"

### DIFF
--- a/ruoyi-common/src/main/java/com/ruoyi/common/utils/ShiroUtils.java
+++ b/ruoyi-common/src/main/java/com/ruoyi/common/utils/ShiroUtils.java
@@ -47,6 +47,10 @@ public class ShiroUtils
     {
         Subject subject = getSubject();
         PrincipalCollection principalCollection = subject.getPrincipals();
+        if (principalCollection.getRealmNames().isEmpty())
+        {
+            return;
+        }
         String realmName = principalCollection.getRealmNames().iterator().next();
         PrincipalCollection newPrincipalCollection = new SimplePrincipalCollection(user, realmName);
         // 重新加载Principal

--- a/ruoyi-framework/src/main/java/com/ruoyi/framework/shiro/util/AuthorizationUtils.java
+++ b/ruoyi-framework/src/main/java/com/ruoyi/framework/shiro/util/AuthorizationUtils.java
@@ -16,7 +16,11 @@ public class AuthorizationUtils
      */
     public static void clearAllCachedAuthorizationInfo()
     {
-        getUserRealm().clearAllCachedAuthorizationInfo();
+        UserRealm ur = getUserRealm();
+        if (ur != null)
+        {
+            ur.clearAllCachedAuthorizationInfo();
+        }
     }
 
     /**
@@ -25,6 +29,10 @@ public class AuthorizationUtils
     public static UserRealm getUserRealm()
     {
         RealmSecurityManager rsm = (RealmSecurityManager) SecurityUtils.getSecurityManager();
+        if (rsm.getRealms().isEmpty()) 
+        {
+            return null;
+        }
         return (UserRealm) rsm.getRealms().iterator().next();
     }
 }


### PR DESCRIPTION
Before call next(), I couldn't find any code logic that ensures the 'getRealms()' is not empty. 
Add a empty check before calling 'iterator().next()' to avoid potential NullPointerExceptions or unexpected behavior.