### PR TITLE
Add repository agent harness context

### DIFF
--- a/.agents/skills/code-change-verification/SKILL.md
+++ b/.agents/skills/code-change-verification/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: code-change-verification
+description: 当变更影响运行时代码、测试、用户可见生成输出、模板或构建/验证行为时，运行仓库强制验证栈。
+---
+
+# 代码变更验证
+
+## 概览
+
+确保只有在仓库自己的 verification checks 运行后，才把工作标记为完成。变更影响运行时代码、测试、用户可见 generated outputs、templates 或 build/test configuration 时使用本 skill。纯文档或仓库元数据变更可跳过，除非用户要求完整验证栈。
+
+## 仓库验证栈
+
+- Setup command: 未配置；未发现 Maven wrapper、setup script、CI 或文档化 install command。
+- Format command: 未配置；未发现 formatter 配置或 format check command。
+- Lint command: 未配置；未发现 lint 配置或 lint command。
+- Typecheck command: 未配置；`pom.xml` 配置了 Java 17 compiler plugin，但没有仓库确认的 compile/typecheck runner。
+- Test command: 未配置；未发现 `src/test*` 测试目录、CI workflow 或文档化 test command。
+- Build command: 未配置；Maven lifecycle 可由 `pom.xml` 推断存在，但没有仓库确认的 official build runner。
+- Full verification command: `make verify` 存在，但 `scripts/run_validation.py` 当前 `CHECKS` 为空，会写 receipt、记录 `not_configured` 并以非零状态退出。
+- Notes: 不要把 `make verify` 的存在等同于通过完整验证；只有在 `CHECKS` 被仓库事实填充并成功运行后，才能报告 full verification passed。
+
+## 快速开始
+
+1. 保持本 skill 位于 [`.agents/skills/code-change-verification`](./)，让仓库能自动加载它。
+2. 对 runtime、template、SQL、configuration、generator、script 或 build/test config 变更，先核对是否已有仓库确认的 runner；当前没有可成功运行的 full verification gate。
+3. 只有用户明确要求配置验证栈，或仓库新增 runner 证据时，才编辑 [`scripts/run_validation.py`](scripts/run_validation.py) 中的 `CHECKS`。
+4. 如果运行 `make verify`，预期当前结果是 `not_configured`；最终回复必须如实说明，而不是报告验证通过。
+5. 如果未来 command 失败，修复问题，重新运行相关 verification stack，并报告最终状态。
+
+## 手动流程
+
+- 当前没有已填充的 setup、format、lint、typecheck、test 或 build command。
+- [`scripts/run_validation.py`](scripts/run_validation.py) 配置完成后，优先使用 `make verify`。
+- 如果没有 configured full verification command，只能报告 verification not configured；不要用推断的 Maven 命令替代仓库 runner。
+- 除非用户明确要求，不要作为本 skill 的一部分新增工具或创建新的 verification commands。
+- 不要把 Maven lifecycle、templates 中的通用示例或 README 背景当成目标仓库已确认 runner。
+- 确认 `.harnesskit/receipts/latest.json` 已写入；有帮助时在最终回复中引用 receipt 路径。
+- 修复后重新运行失败检查，确保报告的验证状态对应最终 working tree。

--- a/.agents/skills/code-change-verification/agents/openai.yaml
+++ b/.agents/skills/code-change-verification/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "代码变更验证"
+  short_description: "运行必需的本地验证栈"
+  default_prompt: "使用 $code-change-verification 运行必需的本地验证栈，并报告任何失败。"

--- a/.agents/skills/code-change-verification/scripts/run_validation.py
+++ b/.agents/skills/code-change-verification/scripts/run_validation.py
@@ -1,0 +1,168 @@
+"""运行仓库验证套件并写入轻量 receipt。
+
+先从本仓库 manifests、scripts、locks、CI config 或团队文档核对真实命令，
+再配置 CHECKS。
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from shlex import join as shell_join
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RECEIPTS_DIR = REPO_ROOT / ".harnesskit" / "receipts"
+RUNS_DIR = RECEIPTS_DIR / "runs"
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    command: tuple[str, ...]
+
+
+CHECKS: tuple[Check, ...] = ()
+
+
+def run_text(command: tuple[str, ...]) -> str | None:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def git_info() -> dict[str, Any]:
+    commit = run_text(("git", "rev-parse", "--short", "HEAD"))
+    status = run_text(("git", "status", "--porcelain"))
+    return {
+        "commit": commit,
+        "dirty": bool(status),
+    }
+
+
+def safe_run_id(started_at: datetime) -> str:
+    return started_at.isoformat(timespec="seconds").replace(":", "-")
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    tmp_path.replace(path)
+
+
+def run_check(check: Check) -> dict[str, Any]:
+    print(f"\n==> {check.name}: {shell_join(check.command)}", flush=True)
+    started = time.monotonic()
+    try:
+        result = subprocess.run(check.command, cwd=REPO_ROOT, check=False)
+        exit_code = result.returncode
+    except FileNotFoundError as error:
+        print(f"未找到命令: {error.filename}", file=sys.stderr, flush=True)
+        exit_code = 127
+    duration = round(time.monotonic() - started, 3)
+
+    return {
+        "name": check.name,
+        "command": shell_join(check.command),
+        "status": "passed" if exit_code == 0 else "failed",
+        "exit_code": exit_code,
+        "duration_seconds": duration,
+    }
+
+
+def write_receipt(
+    *,
+    run_id: str,
+    started_at: datetime,
+    finished_at: datetime,
+    status: str,
+    checks: list[dict[str, Any]],
+    notes: list[str] | None = None,
+) -> Path:
+    receipt: dict[str, Any] = {
+        "schema_version": 1,
+        "type": "validation",
+        "run_id": run_id,
+        "started_at": started_at.isoformat(timespec="seconds"),
+        "finished_at": finished_at.isoformat(timespec="seconds"),
+        "entrypoint": "make verify",
+        "status": status,
+        "git": git_info(),
+        "checks": checks,
+    }
+    if notes:
+        receipt["notes"] = notes
+
+    run_path = RUNS_DIR / f"{run_id}.json"
+    write_json(run_path, receipt)
+    write_json(RECEIPTS_DIR / "latest.json", receipt)
+    return run_path
+
+
+def main() -> int:
+    started_at = datetime.now().astimezone()
+    run_id = safe_run_id(started_at)
+
+    if not CHECKS:
+        finished_at = datetime.now().astimezone()
+        run_path = write_receipt(
+            run_id=run_id,
+            started_at=started_at,
+            finished_at=finished_at,
+            status="not_configured",
+            checks=[],
+            notes=[
+                "尚未配置 validation checks。",
+                "核对仓库命令后，编辑 .agents/skills/code-change-verification/scripts/run_validation.py 中的 CHECKS。",
+            ],
+        )
+        print("验证状态: not_configured", file=sys.stderr, flush=True)
+        print(f"验证 receipt: {run_path.relative_to(REPO_ROOT)}", flush=True)
+        return 1
+
+    checks: list[dict[str, Any]] = []
+    status = "passed"
+    for check in CHECKS:
+        check_result = run_check(check)
+        checks.append(check_result)
+        if check_result["exit_code"] != 0:
+            status = "failed"
+            break
+
+    finished_at = datetime.now().astimezone()
+    run_path = write_receipt(
+        run_id=run_id,
+        started_at=started_at,
+        finished_at=finished_at,
+        status=status,
+        checks=checks,
+    )
+
+    print(f"\n验证 receipt: {run_path.relative_to(REPO_ROOT)}", flush=True)
+    print(f"验证状态: {status}", flush=True)
+    return 0 if status == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/fill-agents/SKILL.md
+++ b/.agents/skills/fill-agents/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: fill-agents
+description: 从 .harnesskit/facts.md 和已核对的仓库证据填充或刷新 AGENTS.md，使其保持为简洁的 agent 启动入口。用于 scan-facts 之后更新操作关键事实、上下文路由、skill 触发点、验证入口、漂移处理，或同步 root/template AGENTS.md 的结构意图。
+---
+
+# 填充 Agents
+
+使用本 skill 更新 [AGENTS.md](../../../AGENTS.md)，把它保持为仓库的 agent 启动入口。[AGENTS.md](../../../AGENTS.md) 应只承载少量操作关键事实，并把 agent 路由到规则、架构地图、skills、验证入口和漂移处理。
+
+[AGENTS.md](../../../AGENTS.md) 不是项目知识库。完整目录地图放到 [ARCHITECTURE.md](../../../ARCHITECTURE.md)，约束放到 [RULES.md](../../../RULES.md)，任务流程放到 [.agents/skills/](../../skills/)，产品背景放到 `README.md` 或 `docs/`。
+
+当仓库同时存在 `templates/AGENTS.md` 时，根目录指南和模板指南要保持结构意图一致，但不要求内容一致。根目录 [AGENTS.md](../../../AGENTS.md) 描述当前仓库；`templates/AGENTS.md` 是生成到目标仓库的通用模板。不要把当前仓库事实无证据复制进模板，也不要把模板占位符当成当前仓库事实。
+
+## 工作流
+
+1. 读取 [.harnesskit/facts.md](../../../.harnesskit/facts.md)、当前 [AGENTS.md](../../../AGENTS.md)、[RULES.md](../../../RULES.md)、[ARCHITECTURE.md](../../../ARCHITECTURE.md)、[.agents/skills/](../../skills/) 中的 skill 文件，以及已存在的 `templates/AGENTS.md`。
+2. 对高影响声明回到真实仓库文件核对；不要只依赖 [.harnesskit/facts.md](../../../.harnesskit/facts.md)、README 叙述、设计文档或模板示例。
+3. 只保留会立刻改变 agent 行动的事实，例如项目类型、命令 runner、用户可见边界、schema/integration 状态、生成输出边界或 companion 指南行为。
+4. 保持路由简洁：说明规则、架构事实、实践指导、产品/设计背景、本地 skills、扫描事实和验证入口在哪里。
+5. 工作策略只写触发点和边界。详细步骤放进 skills；除非仓库确实需要固定步骤，否则不要写成固定流程清单。
+6. 无法确认的内容保留为 `[NEEDS CLARIFICATION: ...]`。
+
+## 输出
+
+默认只更新 [AGENTS.md](../../../AGENTS.md)，除非用户明确要求同步更新生成模板。如果 `templates/AGENTS.md` 需要匹配的结构调整，把它作为带占位符的通用模板更新，而不是复制根目录内容。如果 rules、architecture、验证 skill 或其他资产也需要变化，在最终总结中说明，或调用对应 fill skill。
+
+推荐的根目录结构：
+
+- 职责或定位说明
+- 操作关键事实
+- 上下文路由
+- 工作策略或 skill 触发点
+- 验证入口
+- 漂移处理
+
+## 边界
+
+- 不要把完整架构地图、规则全集、逐条 Rule 路由、skill 正文或长篇产品背景复制进 [AGENTS.md](../../../AGENTS.md)。
+- 不要要求 [AGENTS.md](../../../AGENTS.md) 列出每条规则、每个流程、每个路径，或固定数量的事实。
+- 不要虚构验证命令、CI、分支保护、PR 模板或发布流程。
+- 不要把 `templates/AGENTS.md` 里的示例或占位符写成当前仓库事实。
+- 不要把 [.harnesskit/facts.md](../../../.harnesskit/facts.md) 当成高影响声明的唯一事实来源；必须回到仓库文件核对。

--- a/.agents/skills/fill-agents/agents/openai.yaml
+++ b/.agents/skills/fill-agents/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "填充 Agents"
+  short_description: "从 facts 填充 AGENTS.md"
+  default_prompt: "使用 $fill-agents 从 .harnesskit/facts.md 和已核对的仓库证据更新 AGENTS.md。"

--- a/.agents/skills/fill-architecture/SKILL.md
+++ b/.agents/skills/fill-architecture/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: fill-architecture
+description: 从 .harnesskit/facts.md 和已核对的仓库证据填充或刷新 ARCHITECTURE.md，使其保持为粗粒度仓库地图。用于 scan-facts 之后更新重要路径、模块职责、生成资产、外部状态和容易混淆的实现边界。
+---
+
+# 填充 Architecture
+
+使用本 skill 更新 [ARCHITECTURE.md](../../../ARCHITECTURE.md)，把它保持为给 agent 和贡献者使用的粗粒度仓库地图。它回答“修改前应该先看哪里”，不回答完整 API、完整工作流或详细设计。
+
+[ARCHITECTURE.md](../../../ARCHITECTURE.md) 不是文件清单。只记录能帮助 agent 定位代码区域、理解职责边界或识别生成/外部状态的路径；不要因为某个 helper、测试文件或 rule module 存在就逐个列出。
+
+当仓库同时存在 `templates/ARCHITECTURE.md` 时，根目录地图和模板地图要保持结构意图一致，但不要求内容一致。根目录 [ARCHITECTURE.md](../../../ARCHITECTURE.md) 描述当前仓库；`templates/ARCHITECTURE.md` 是生成到目标仓库的通用模板。不要把当前仓库路径无证据复制进模板，也不要把模板占位符当成当前仓库事实。
+
+## 工作流
+
+1. 读取 [.harnesskit/facts.md](../../../.harnesskit/facts.md)、当前 [ARCHITECTURE.md](../../../ARCHITECTURE.md)、[AGENTS.md](../../../AGENTS.md)、[RULES.md](../../../RULES.md)、顶层目录、构建清单、测试入口、脚本和现有文档。
+2. 对路径职责和边界回到真实仓库文件核对；不要只依赖 [.harnesskit/facts.md](../../../.harnesskit/facts.md)、README 叙述、设计文档或模板示例。
+3. 优先记录顶层目录、重要入口文件、生成资产、持久配置、外部状态、发布产物和容易混淆的边界。
+4. 对子目录只展开到能改变 agent 查找路径的层级；不要展开到每个 helper 文件、每个测试文件或每个规则模块。
+5. `<!-- harnesskit:coverage=direct-children -->` 只加在确实需要 direct-child coverage 的重要目录上，并且必须先验证路径和职责。
+6. 无法确认的内容保留为 `[NEEDS CLARIFICATION: ...]`。
+
+## 输出
+
+默认只更新 [ARCHITECTURE.md](../../../ARCHITECTURE.md)，除非用户明确要求同步更新生成模板。如果 `templates/ARCHITECTURE.md` 需要匹配的结构调整，把它作为带占位符的通用模板更新，而不是复制根目录内容。如果 rules、agent 路由、skill 触发点或验证入口也需要变化，在最终总结中说明，或调用对应 fill skill。
+
+推荐结构：
+
+- 顶层地图
+- 关键文件
+- 生成资产和外部状态
+- 边界说明
+- 更新规则
+
+## 边界
+
+- 不要把 [ARCHITECTURE.md](../../../ARCHITECTURE.md) 写成工作流指南、API 参考、完整文件清单、测试清单或设计长文。
+- 不要列出 generated、vendor、cache、build output，除非它们是 agent-facing contract、发布产物或必须人工维护的生成资产。
+- 不要把旧 POC、示例或设计愿景写成当前产品入口；需要明确旧实现和当前 runtime 的边界。
+- 不要把模板中的 `[NEEDS CLARIFICATION: ...]` 或示例路径写成当前仓库事实。
+- 如果本 skill 的旧写法与 [AGENTS.md](../../../AGENTS.md) 中的职责分层原则冲突，以 [AGENTS.md](../../../AGENTS.md) 为准，并同步修正本 skill。

--- a/.agents/skills/fill-architecture/agents/openai.yaml
+++ b/.agents/skills/fill-architecture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "填充 Architecture"
+  short_description: "从 facts 填充 ARCHITECTURE.md"
+  default_prompt: "使用 $fill-architecture 从 .harnesskit/facts.md 和已核对的仓库路径更新 ARCHITECTURE.md。"

--- a/.agents/skills/fill-practices/SKILL.md
+++ b/.agents/skills/fill-practices/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: fill-practices
+description: 从 .harnesskit/facts.md 和已核对的仓库证据填充或刷新 docs/practices/*.md。用于 scan-facts 之后更新 coding、product sense、security、reliability 等判断指导，而不是把每条建议都升级成 RULES.md 规则。
+---
+
+# 填充 Practices
+
+使用本 skill 更新 [docs/practices/](../../../docs/practices/)，让它成为 coding、product sense、security 和 reliability 的判断指导层。Practices 解释“如何判断”；[RULES.md](../../../RULES.md) 记录硬约束。
+
+## 工作流
+
+1. 读取 [.harnesskit/facts.md](../../../.harnesskit/facts.md)、[AGENTS.md](../../../AGENTS.md)、[RULES.md](../../../RULES.md)、[ARCHITECTURE.md](../../../ARCHITECTURE.md)，以及 [docs/practices/](../../../docs/practices/) 下的现有文件。
+2. 对高影响声明回到 source、tests、templates、scripts、manifests、hooks 和已有 docs 核对。
+3. 只更新 practice guidance：判断原则、Do/Don't、review questions、examples 和边界说明。
+4. 硬约束不要放进 practices，除非它们也已出现在 [RULES.md](../../../RULES.md)，或明确标记为 candidate rules。
+5. 如果 practice 暴露了新的稳定硬约束，说明应由 `$fill-rules` 添加或更新对应 `RULE-*.md` details；不要在这里静默升级。
+6. 当仓库证据不足时，用 `[NEEDS CLARIFICATION: ...]` 保留不确定性。
+
+## Practice 文件
+
+- `CODING.md`: code style、抽象边界、测试、注释和可维护性判断。
+- `PRODUCT_SENSE.md`: product north star、CLI UX、模板体验、lint messages 和用户信任。
+- `SECURITY.md`: secret handling、文件写入、path safety、依赖和报告/输出泄漏。
+- `RELIABILITY.md`: 受保护边界、验证策略、失败处理、兼容性和 drift prevention。
+
+## 边界
+
+- 没有证据和清晰违规形态时，不要把通用建议变成 rules。
+- 没核对当前实现前，不要用 roadmap 或 design docs 覆盖产品事实。
+- 不要虚构 security policy、CI、support versions、release gates 或 disclosure SLAs。
+- 除非用户明确要求同步模板，否则不要更新 generated templates。

--- a/.agents/skills/fill-practices/agents/openai.yaml
+++ b/.agents/skills/fill-practices/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "填充 Practices"
+  short_description: "填充判断指导文档"
+  default_prompt: "使用 $fill-practices 从 .harnesskit/facts.md 和已核对的仓库证据更新 docs/practices/*.md。"

--- a/.agents/skills/fill-rules/SKILL.md
+++ b/.agents/skills/fill-rules/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: fill-rules
+description: 从 .harnesskit/facts.md 和已核对的仓库证据填充或刷新 RULES.md 短规则索引与 .harnesskit/rules/RULE-*.md details。用于 scan-facts 之后更新可执行规则、rule details、validation context 和 runner bindings。
+---
+
+# 填充 Rules
+
+使用本 skill 更新 [RULES.md](../../../RULES.md) 作为短约束索引，并更新 [.harnesskit/rules/](../../../.harnesskit/rules/) 下的 `RULE-*.md` 作为 details 层。
+
+## 工作流
+
+1. 读取 [.harnesskit/facts.md](../../../.harnesskit/facts.md)、当前 [RULES.md](../../../RULES.md)、[.harnesskit/rules/](../../../.harnesskit/rules/)、validation scripts、manifests、hook/CI config 和 agent guidance。
+2. 只有当事项是仓库本地约束或已明确采纳、跨任务稳定、有清晰违规形态，并且有证据支撑时，才升级为 Rule。
+3. 写入 [RULES.md](../../../RULES.md) 或 [.harnesskit/rules/](../../../.harnesskit/rules/) `RULE-*.md` 文件前，把 candidate rule changes 作为 single-choice MCQ 展示给用户。如果当前 Codex surface 支持 native single-choice UI，就使用它；否则把选项渲染成文本并等待用户字母或修正。
+   - A. 确认所有 candidate rule changes 并写入。
+   - B. 写入前先修正一个或多个 candidate rules。
+   - C. 暂时跳过 rule changes 写入。
+   - D. 只写入 high-confidence repository rules，其余保留为 `[NEEDS CLARIFICATION: ...]`。
+   如果用户修正规则、分类、validation binding 或 runner status，把该修正视为 user-confirmed evidence 并记录。
+4. category headings 只用于组织；不要把 general engineering、AI coding、stack、architecture 或 domain 等分类本身当成启用规则的证据。
+5. [RULES.md](../../../RULES.md) 中每条 rule 保持为一句短约束，并链接到对应 details 文件。
+6. 将 rationale、evidence、validation context、runner bindings、caveats 和 examples 放入 [.harnesskit/rules/](../../../.harnesskit/rules/) 中对应 details 文件的 `## Details` section；不要要求单独的 `## Validation` heading。
+7. 对 unsupported 或 unverified rules 标记为 `[NEEDS CLARIFICATION: ...]`、`N/A`、`未配置` 或 `不适用`，不要从示例直接启用。
+8. 在 details 文件中区分 rule、validation/check 和 runner；没有 runner 证据时，不要声称某个检查会阻断变更。
+9. 除非用户明确要求迁移，否则保留已有客户手写 rules 和结构。
+
+## 用户确认协议
+
+使用类似下面的简短 MCQ 确认提示：
+
+```text
+我找到这些候选 Rule 变更。写入 `RULES.md` 和 `.harnesskit/rules/RULE-*.md` 前请确认。
+
+1. 新增 / 更新 rule: RULE-...
+   约束: ...
+   分类: ...
+   证据: ...
+   Validation: ...
+   Runner / binding: ...
+
+2. 保留未解决事项: ...
+   原因: ...
+
+请选择：
+A. 确认所有 candidate rule changes 并写入。
+B. 写入前先修正一个或多个 candidate rules。
+C. 暂时跳过 rule changes 写入。
+D. 只写入 high-confidence repository rules，其余保留为 `[NEEDS CLARIFICATION: ...]`。
+```
+
+如果当前 Codex surface 有 native single-choice UI，用该 UI 展示四个选项；否则使用上方文本 MCQ。然后暂停等待用户回复。没有用户确认时，不要把 facts、通用工程建议、template examples 或 inferred commands 静默升级成 durable Rules。
+
+## 输出
+
+只更新 [RULES.md](../../../RULES.md) 和 [.harnesskit/rules/](../../../.harnesskit/rules/) 下的 `RULE-*.md` 文件。如果 [AGENTS.md](../../../AGENTS.md)、[ARCHITECTURE.md](../../../ARCHITECTURE.md) 或 skills 需要匹配变更，调用对应 fill skill。
+
+## 边界
+
+- 不要虚构 commands、CI、branch protection、coverage thresholds、typecheck、docs build 或 PR requirements。
+- 不要把通用工程建议、任务步骤、工具教程、临时计划或未验证猜测变成 Rules。
+- workflows 放进 skills 或 [AGENTS.md](../../../AGENTS.md)；目录地图放进 [ARCHITECTURE.md](../../../ARCHITECTURE.md)；产品背景放进 README 或 docs。
+- 不要把局部 review judgment 标记为确定性 validation coverage。
+- 不要把 [.harnesskit/facts.md](../../../.harnesskit/facts.md) 当成核对真实 runner config 的替代品。
+- 除非用户明确要求迁移，否则不要重构现有非模板 [RULES.md](../../../RULES.md)。

--- a/.agents/skills/fill-rules/agents/openai.yaml
+++ b/.agents/skills/fill-rules/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "填充 Rules"
+  short_description: "填充短规则和 details"
+  default_prompt: "使用 $fill-rules 从 facts 和已核对的 validation runner 证据更新 RULES.md 与 .harnesskit/rules/RULE-*.md。"

--- a/.agents/skills/fill-skills/SKILL.md
+++ b/.agents/skills/fill-skills/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: fill-skills
+description: 从 .harnesskit/facts.md 填充 generated skills 中的项目特定 section。用于 scan-facts 之后配置验证命令、兼容性边界、PR summary category signals 或其他本地 skill placeholders。
+---
+
+# 填充 Skills
+
+使用本 skill 更新 generated skills 内的项目特定 section。它读取 [.harnesskit/facts.md](../../../.harnesskit/facts.md)，并对高影响声明回到仓库证据核对。
+
+## 工作流
+
+1. 读取 [.harnesskit/facts.md](../../../.harnesskit/facts.md) 和 [.agents/skills/](../../skills/) 下的 generated skills。
+2. 只更新 intended-to-fill 的项目特定 section，例如 verification stack、compatibility boundaries、PR summary category signals 和 local trigger notes。
+3. 除非 generic procedural guidance 与仓库事实冲突，否则保持稳定。
+4. 未解决事项保留为 `[NEEDS CLARIFICATION: ...]`。
+5. 如果变更影响 [AGENTS.md](../../../AGENTS.md)、[ARCHITECTURE.md](../../../ARCHITECTURE.md) 或 [RULES.md](../../../RULES.md)，调用对应 fill skill，不要从这里直接编辑那些 artifact。
+
+## 输出
+
+只有当项目特定 placeholders 能从 facts 和仓库证据解析时，才更新 [.agents/skills/](../../skills/) 下的文件。
+
+## 边界
+
+- 不要新增工具或验证命令，除非仓库已经定义它们，或用户明确要求该变更。
+- 不要把 skill 正文改写成项目文档。
+- 不要移除仍代表真实不确定性的 placeholders。

--- a/.agents/skills/fill-skills/agents/openai.yaml
+++ b/.agents/skills/fill-skills/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "填充 Skills"
+  short_description: "填充 generated skill placeholders"
+  default_prompt: "使用 $fill-skills 从 .harnesskit/facts.md 和已核对的仓库证据更新 generated skills。"

--- a/.agents/skills/harness-init/SKILL.md
+++ b/.agents/skills/harness-init/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: harness-init
+description: 在 harnesskit init 之后编排 Context Harness 初始化。用于通过 scan-facts、fill-agents、fill-architecture、fill-practices、fill-rules、fill-skills 和最终一致性检查来启动或刷新 generated harness。
+---
+
+# Harness 初始化
+
+把本 skill 作为 `harnesskit init` 之后的第一个用户可见 workflow。它协调 fact-first fill flow，而不是把每个专项指令复制进一个巨大的 skill。
+
+## 工作流
+
+1. 使用 $scan-facts 检查仓库证据，并在写入 durable facts 前，请用户确认候选 project identity、purpose、stack、validation entrypoints 和重要边界。
+2. 在写入 durable guidance 前，先解决 facts 无法确定的高影响问题。
+3. 使用 $fill-architecture 更新 [ARCHITECTURE.md](../../../ARCHITECTURE.md)。
+4. 使用 $fill-practices 更新 [docs/practices/](../../../docs/practices/) 判断指导。
+5. 使用 $fill-rules 展示 candidate rule changes 并请求用户确认，然后更新 [RULES.md](../../../RULES.md) 和 [.harnesskit/rules/](../../../.harnesskit/rules/) 下的 `RULE-*.md` 文件。
+6. 使用 $fill-agents 更新 [AGENTS.md](../../../AGENTS.md)。
+7. 使用 $fill-skills 更新 generated skills 中的项目特定 section。
+8. 检查 [.harnesskit/facts.md](../../../.harnesskit/facts.md)、[AGENTS.md](../../../AGENTS.md)、[ARCHITECTURE.md](../../../ARCHITECTURE.md)、[RULES.md](../../../RULES.md)、[docs/practices/](../../../docs/practices/)、[.agents/skills/](../../skills/)、[CLAUDE.md](../../../CLAUDE.md) 和 verification entrypoint 的一致性。
+
+## 一致性检查
+
+检查：
+
+- [AGENTS.md](../../../AGENTS.md) 引用的 skills 都存在于 [.agents/skills/](../../skills/)；
+- [AGENTS.md](../../../AGENTS.md) 将地图路由到 [ARCHITECTURE.md](../../../ARCHITECTURE.md)、rules 路由到 [RULES.md](../../../RULES.md)、procedures 路由到 skills；
+- [docs/practices/](../../../docs/practices/) 承载判断指导，硬约束仍留在 [RULES.md](../../../RULES.md)；
+- [RULES.md](../../../RULES.md) 中的 command bindings 与 verification skill 和 runner config 一致；
+- [ARCHITECTURE.md](../../../ARCHITECTURE.md) 链接指向真实路径；
+- 未解决的不确定性仍保留为 `[NEEDS CLARIFICATION: ...]`。
+
+## 边界
+
+- 不要让本 skill 取代专项 fill skills；按顺序调用它们。
+- 不要虚构 repository facts、commands、CI、branch protection 或 release policy。
+- 对 guidance-only edits 不要运行完整 runtime verification，除非这些编辑也影响运行时代码、模板、构建/测试配置或生成行为。

--- a/.agents/skills/harness-init/agents/openai.yaml
+++ b/.agents/skills/harness-init/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harness 初始化"
+  short_description: "运行 fact-first harness 填充流程"
+  default_prompt: "使用 $harness-init 运行 scan-facts，填充包含 practices 在内的 harness artifacts，并检查一致性。"

--- a/.agents/skills/implementation-strategy/SKILL.md
+++ b/.agents/skills/implementation-strategy/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: implementation-strategy
+description: 编辑代码前决定实现策略。用于任务会改变导出 API、运行时行为、序列化状态、测试或文档，并且需要判断兼容性边界、是否需要 shim/migration，以及未发布接口能否直接重写时。
+---
+
+# 实现策略
+
+## 概览
+
+当任务会改变运行时行为，或任何看起来可能涉及兼容性的内容时，在编辑代码前使用本 skill。目标是在保护真实已发布契约的同时，让实现保持简单。
+
+## 快速开始
+
+1. 识别正在改变的 surface：已发布 public API、未发布 branch-local API、internal helper、persisted schema、wire protocol、CLI/config/env surface，或仅 docs/examples。
+2. 确定最新 release 边界。如果仓库指南指定 release tag pattern，使用该 pattern；否则使用最新可达 tag：
+   ```bash
+   BASE_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+   echo "$BASE_TAG"
+   ```
+3. 如果没有 release tag，明确说明，并只按 documented public contracts 和 durable external state 判断兼容性。
+4. 按最新 release tag 或已记录 compatibility policy 判断 breaking-change risk，不要按未发布 branch churn 或 default branch 上 release 后变更判断。
+5. 优先选择满足当前任务的最简单实现。直接更新 callers、tests、docs 和 examples，不要保留已被取代的未发布接口。
+6. 只有存在具体 released consumer、受支持的 durable external state boundary 确实需要，或用户明确要求 migration path 时，才添加 compatibility layer。
+
+## 兼容性边界规则
+
+- Released public API 或 documented external behavior：保留兼容性，或提供明确 migration path。
+- Persisted schema、serialized state、wire protocol、CLI flags、environment variables 和 externally consumed config：当它们属于最新 release，或仓库明确表示要跨 commit、process 或 machine 保留时，按 compatibility-sensitive 处理。
+- 只在当前 branch 引入的 interface changes：不是 compatibility target，直接重写。
+- 已在 default branch 但晚于最新 release tag 的 interface changes：本身不构成 breaking change。除非它们已经定义已发布或明确支持的 durable external state boundary，否则直接重写。
+- Internal helpers、private types、same-branch tests、fixtures 和 examples：直接更新，不要添加 adapters。
+- default branch 上未发布的 persisted schema versions：当中间快照明确不受支持时，可在 release 前重新编号或 squash。
+
+## 默认实现立场
+
+- 当旧形态未发布时，优先删除或替换，而不是添加 aliases、overloads、shims、feature flags 或 dual-write logic。
+- 不要因为某个混乱抽象已经存在于当前 branch diff，就保留它。
+- 如果 review feedback 声称某个改动是 breaking change，先按最新 release tag 和真实外部影响核对，再接受反馈。
+- 如果变更确实跨越最新 released contract boundary，在 implementation notes、release notes context 和用户可见总结中明确说明。
+
+## 项目特定兼容性规则
+
+- 已发布边界：仓库存在 `v4.x.y` release tags，当前本地版本为 `v4.8.3`；默认使用 `git describe --tags --abbrev=0` 识别最新可达 release tag，除非用户或仓库文档另行指定。
+- 用户可见 runtime surface：`ruoyi-admin` controllers、Thymeleaf templates、static assets、Springdoc/OpenAPI exposure、Quartz job pages、错误页、登录/注册/权限相关页面。
+- 外部配置 surface：`ruoyi-admin/src/main/resources/application.yml`、`application-druid.yml`、Shiro/session/remember-me/captcha、XSS/CSRF、Druid monitor、upload profile、server/context path 和 datasource settings。
+- 持久化 / schema surface：`sql/` scripts、MyBatis mapper XML、domain/service changes that alter database reads/writes、Quartz tables/jobs and generated SQL output。
+- 生成输出 surface：`ruoyi-generator/src/main/resources/generator.yml`、`ruoyi-generator/src/main/resources/vm/` 和 generator UI templates；`allowOverwrite: false` 是当前文件覆盖边界。
+- Operations / package surface：`pom.xml`、module `pom.xml` files、`Makefile`、`bin/`、`ry.sh`、`ry.bat` and packaged `ruoyi-admin` jar/war behavior.
+- 未文档化边界：没有发现本仓库自定义 deprecation、migration 或 schema-version policy；触及 SQL schema、外部配置、生成输出或运行脚本时，在实现说明中明确兼容性判断和未配置验证缺口。
+
+## 何时停止并确认
+
+- 变更会改变最新 release tag 已发布的行为。
+- 变更会修改 durable external data、protocol formats 或 serialized state。
+- 变更会修改 `sql/` schema/data、MyBatis mapper XML、application YAML、generator overwrite behavior、生成模板或运行/打包脚本。
+- 用户明确要求 backward compatibility、deprecation 或 migration support。
+
+## 输出期望
+
+当本 skill 实质影响实现方式时，在 reasoning 或 handoff 中简要说明决策，例如：
+
+- `Compatibility boundary: latest release tag v0.x.y; branch-local interface rewrite, no shim needed.`
+- `Compatibility boundary: released schema; preserve compatibility and add migration coverage.`

--- a/.agents/skills/implementation-strategy/agents/openai.yaml
+++ b/.agents/skills/implementation-strategy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "实现策略"
+  short_description: "选择兼容性明确的实现方案"
+  default_prompt: "使用 $implementation-strategy 在编辑运行时代码前选择实现方式和兼容性边界。"

--- a/.agents/skills/pr-draft-summary/SKILL.md
+++ b/.agents/skills/pr-draft-summary/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pr-draft-summary
+description: 生成所需的 PR-ready summary block、branch suggestion、title 和 draft description。用于中等及以上规模的运行时代码、测试、示例、构建/测试配置或有行为影响的文档变更完成后的最终交付；仅在 trivial/conversation-only、无行为影响的 repo-meta/doc-only 任务，或用户明确不要 PR draft block 时跳过。
+---
+
+# PR 草稿总结
+
+## 目的
+在实质性代码工作完成后，生成本仓库需要的 PR-ready summary：简短总结、可用 PR title，以及以 "This pull request <verb> ..." 开头的 draft description。输出块应可直接粘贴进 PR。
+
+## 触发条件
+
+- 本仓库任务已完成（或 ready for review），且触及运行时代码、SQL、templates、static assets、generator output、configuration、scripts、Maven build/dependency config 或有行为影响的 docs。
+- 对实质性代码工作，把它作为默认 final handoff step。在所需验证或 changeset 工作完成后、发送“完成”回复前执行。
+- 仅在 trivial/conversation-only、无行为影响的 repo-meta/guidance-only 任务，或用户明确不要 PR draft block 时跳过。
+
+## 自动收集的输入（不要询问用户）
+
+- 当前 branch：`git rev-parse --abbrev-ref HEAD`。
+- Working tree：`git status -sb`。
+- Untracked files：`git ls-files --others --exclude-standard`。
+- Changed files：`git diff --name-only`（unstaged）和 `git diff --name-only --cached`（staged）；sizes 用 `git diff --stat` 和 `git diff --stat --cached`。
+- 最新 release tag（可用时）：`LATEST_RELEASE_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)`。
+- Base reference：
+  - 优先使用 branch upstream：`BASE_REF=$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || true)`。
+  - 如果没有 upstream，尝试 remote default branch：`BASE_REF=${BASE_REF:-$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)}`。
+  - 如果存在 base reference，计算 base commit：`BASE_COMMIT=$(git merge-base --fork-point "$BASE_REF" HEAD 2>/dev/null || git merge-base "$BASE_REF" HEAD 2>/dev/null || true)`。
+- Base fork point 之后的 commits（可用时）：`test -n "$BASE_COMMIT" && git log --oneline --no-merges ${BASE_COMMIT}..HEAD`。
+- 本仓库 category signals：
+  - Runtime 或 product behavior：`ruoyi-admin/src/main/java/**`, `ruoyi-framework/src/main/java/**`, `ruoyi-system/src/main/java/**`, `ruoyi-common/src/main/java/**`, `ruoyi-quartz/src/main/java/**`, `ruoyi-generator/src/main/java/**`。
+  - User-visible pages/assets：`ruoyi-admin/src/main/resources/templates/**`, `ruoyi-admin/src/main/resources/static/**`, `ruoyi-quartz/src/main/resources/templates/**`。
+  - Generated output / generator behavior：`ruoyi-generator/src/main/resources/vm/**`, `ruoyi-generator/src/main/resources/templates/**`, `ruoyi-generator/src/main/resources/generator.yml`。
+  - Persistence / SQL mapping：`sql/**`, `ruoyi-system/src/main/resources/mapper/**`, `ruoyi-quartz/src/main/resources/mapper/**`, `ruoyi-generator/src/main/resources/mapper/**`。
+  - External config / security config：`ruoyi-admin/src/main/resources/application.yml`, `ruoyi-admin/src/main/resources/application-druid.yml`, `ruoyi-admin/src/main/resources/logback.xml`, `ruoyi-admin/src/main/resources/ehcache/**`, `ruoyi-admin/src/main/resources/mybatis/**`。
+  - Build、packaging、dependency 或 scripts：`pom.xml`, `ruoyi-*/pom.xml`, `Makefile`, `bin/**`, `ry.sh`, `ry.bat`。
+  - Tests：当前未发现 `src/test*` 测试目录；如果未来新增，按实际路径分类。
+  - Documentation with behavior impact：`README.md`, `doc/**`, `docs/**`。
+  - Agent 或 repository policy metadata：`AGENTS.md`, `ARCHITECTURE.md`, `RULES.md`, `.harnesskit/**`, `.agents/**`, `docs/practices/**`, `CLAUDE.md`。
+
+## 工作流
+1. 运行上述命令，不要询问用户。如果无法发现 `BASE_REF`、`BASE_COMMIT` 或 `LATEST_RELEASE_TAG`，继续执行；只有当不确定性影响 PR summary 时才说明。
+2. 如果没有 staged/unstaged/untracked changes，且没有 `BASE_COMMIT` 或 `${BASE_COMMIT}` 之后没有 commits，简短说明未检测到代码变更，并跳过 PR block。
+3. 根据 touched paths 和 diff content 推断 change type，分类为 feature、fix、refactor、docs-with-impact 或 repo-guidance。只有 diff 改变已发布 public behavior、external config、SQL/schema、generated output、serialized state、runtime routes 或 operation scripts 时，才标记 backward-compatibility risk。有 `LATEST_RELEASE_TAG` 时按它判断；没有 tag 时按已记录 compatibility policy 判断。
+4. 用关键路径（top 5）和 `git diff --stat` output 在 1-3 句内总结变化；明确说明 untracked files，因为 `--stat` 不包含它们。如果 working tree 干净但 `${BASE_COMMIT}` 之后有 commits，用 commit messages 总结。
+5. 选择 description lead verb：feature -> `adds`，bug fix -> `fixes`，refactor/perf -> `improves` 或 `updates`，docs-only -> `updates`。
+6. 建议 branch name。如果已经不在 default branch，保留当前 branch；否则按主要领域建议 `feat/<slug>`、`fix/<slug>` 或 `docs/<slug>`。如果无法发现 default branch，不要假装已经知道。
+7. 如果当前 branch 匹配 `issue-<number>`（仅数字），保留该 branch suggestion。只有在已知仓库托管平台支持 auto-closing syntax 时，才包含类似 `This pull request resolves #<number>.` 的 line；否则只提及 issue reference，不声称 auto-close。
+8. 使用下方模板起草 PR title 和 description。
+9. 只输出 "Output Format" 中的 block。
+
+## 输出格式
+结束任务时，除非任务属于记录的跳过条件，或用户说不需要，否则在简短状态说明后添加下面的 Markdown block。
+
+```
+# Pull Request Draft
+
+## Branch name suggestion
+
+git checkout -b <kebab-case suggestion, e.g., feat/add-login-flow>
+
+## Title
+
+<single-line imperative title; conventional commit prefix like feat:, fix:, chore: preferred>
+
+## Description
+
+<start with "This pull request adds/fixes/improves ..."; explain the background and what changed; use bullets for detail if needed>
+```
+
+保持精简：不要在 block 周围添加重复说明，也避免在 changes 和 description 之间重复细节。除非用户特别要求，否则不需要列出 tests。

--- a/.agents/skills/pr-draft-summary/agents/openai.yaml
+++ b/.agents/skills/pr-draft-summary/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR 草稿总结"
+  short_description: "起草仓库可用的 PR 标题和描述"
+  default_prompt: "使用 $pr-draft-summary 为当前变更生成 PR-ready summary block、标题和 draft description。"

--- a/.agents/skills/scan-facts/SKILL.md
+++ b/.agents/skills/scan-facts/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: scan-facts
+description: 从已核对证据扫描仓库事实并写入 .harnesskit/facts.md。用于填充 AGENTS.md、ARCHITECTURE.md、RULES.md 或项目特定 skill section 前，启动或刷新 Context Harness facts。
+---
+
+# 扫描 Facts
+
+使用本 skill 从仓库证据刷新 [.harnesskit/facts.md](../../../.harnesskit/facts.md)。本 skill 是唯一应该创建或刷新 facts artifact 的 generated skill。
+
+## 输入
+
+读取最小但足够有用的 repository-owned evidence：
+
+- Existing guidance：[AGENTS.md](../../../AGENTS.md)、[CLAUDE.md](../../../CLAUDE.md)、[RULES.md](../../../RULES.md)、[.agents/skills/](../../skills/) skill files、architecture notes 和相关 docs。
+- Project identity：`README*`、product/design docs、package metadata 和顶层目录名。
+- Tech stack facts：manifests、lockfiles、workspace files、source/test layout、tool config、CI/pre-commit config 和 documented commands。
+- Current state：`[NEEDS CLARIFICATION: ...]` placeholders、todo-checklist marker blocks、missing files、stale paths，或与仓库文件冲突的 guidance。
+
+忽略 local/generated/vendor 噪音，例如 virtual environments、dependency folders、caches、build output、downloaded dependencies 和 editor metadata，除非用户明确询问。
+
+## 工作流
+
+1. 在提问前先检查仓库事实。
+2. 写入 durable facts 前，先为用户准备简短的 "candidate facts" 确认消息。包含：
+   - project name；
+   - project purpose；
+   - 有证据时的 primary audience；
+   - language/runtime/platform 和 key frameworks；
+   - package/build/test/lint/format entrypoints；
+   - important source、test、docs、specs、scripts 和 config directories；
+   - 任何需要人类选择的 high-impact uncertainty。
+3. 用 single-choice MCQ 请求用户确认或修正 candidate facts。如果当前 Codex surface 支持 native single-choice UI，就使用它；否则把选项渲染成文本并等待用户字母或修正。
+   - A. 确认所有 candidate facts 并写入。
+   - B. 写入前先修正一个或多个 facts。
+   - C. 暂时跳过 durable facts 写入。
+   - D. 只写入 high-confidence repository facts，并把 human-owned items 保留为 `[NEEDS CLARIFICATION: ...]`。
+   如果用户修正 fact，把该修正视为 user-confirmed evidence 并记录。
+4. 只有确认后，才把 evidence-backed 或 user-confirmed facts 记录到 [.harnesskit/facts.md](../../../.harnesskit/facts.md)。
+5. 对 unresolved items 保留 `[NEEDS CLARIFICATION: ...]`，并简短说明缺少什么证据。
+6. 不要从本 skill 更新 [AGENTS.md](../../../AGENTS.md)、[ARCHITECTURE.md](../../../ARCHITECTURE.md)、[RULES.md](../../../RULES.md) 或其他 skills。
+7. 如果 [.harnesskit/facts.md](../../../.harnesskit/facts.md) 缺失，使用 generated template 的相同 sections 重建。
+
+## 用户确认协议
+
+使用类似下面的简短 MCQ 确认提示：
+
+```text
+我检测到这些候选 Harness facts。写入 `.harnesskit/facts.md` 前请确认。
+
+1. Project name: ...
+   Evidence: ...
+
+2. Project purpose: ...
+   Evidence: ...
+
+3. Tech stack: ...
+   Evidence: ...
+
+4. Validation entrypoints: ...
+   Evidence: ...
+
+5. Important directories: ...
+   Evidence: ...
+
+请选择：
+A. 确认所有 candidate facts 并写入。
+B. 写入前先修正一个或多个 facts。
+C. 暂时跳过 durable facts 写入。
+D. 只写入 high-confidence repository facts，并把 human-owned items 保留为 `[NEEDS CLARIFICATION: ...]`。
+```
+
+如果当前 Codex surface 有 native single-choice UI，用该 UI 展示四个选项；否则使用上方文本 MCQ。然后暂停等待用户回复。当扫描包含可由人类确认的用户可见 project identity、purpose、stack、validation commands 或 important boundaries 时，不要静默写入 durable facts。
+
+如果用户明确要求 non-interactive scan，或当前环境无法 follow-up interaction，则写入 high-confidence repository facts，并把所有 uncertain 或 human-owned facts 保留为 `[NEEDS CLARIFICATION: ...]`。
+
+## 事实模型
+
+记录：
+
+- Project identity 和 audience。
+- Languages、runtimes、package managers、frameworks、build tools、test frameworks、linters、formatters 和 type checkers。
+- Validation entrypoints：setup、full verify、test、lint、format check、typecheck、coverage、build、docs、link check、hook suite 和 CI/platform gates。
+- Repository map candidates：重要 source、test、docs、config、generated-output 和 tooling paths。
+- Agent-facing assets 和 installed local skills。
+- 带 runner evidence 的 Rule 与 Validation candidates。
+- 仓库事实无法确定的 open questions。
+
+## 边界
+
+- 不要虚构 commands、tools、URLs、CI、release processes、PR templates、architecture 或 compatibility policy。
+- 不要把 generic template examples 当成目标仓库支持某工具的证据。
+- 除非 command、script、hook、CI task 或 platform setting 提供明确 pass/fail 证据，否则不要把 Validation 标记为 deterministic。
+- guidance-only refresh 不要运行 runtime test suites，除非 refresh 也改变运行时代码、模板、构建/测试配置或生成行为。

--- a/.agents/skills/scan-facts/agents/openai.yaml
+++ b/.agents/skills/scan-facts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "扫描 Facts"
+  short_description: "把仓库证据扫描进 facts 快照"
+  default_prompt: "使用 $scan-facts 从已核对仓库证据刷新 .harnesskit/facts.md，且不更新其他 harness artifacts。"

--- a/.harnesskit/config.json
+++ b/.harnesskit/config.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "project_name": "RuoYi",
+  "harnesskit_version": "0.1.1",
+  "default_integration": "codex",
+  "installed_integrations": [
+    "codex"
+  ]
+}

--- a/.harnesskit/facts.md
+++ b/.harnesskit/facts.md
@@ -1,0 +1,89 @@
+# RuoYi Harness Facts
+
+本文件位于 `.harnesskit/facts.md`，是 `scan -> fill` 工作流的事实交接快照。`$scan-facts` 从仓库事实刷新本文件；`$fill-agents`、`$fill-architecture`、`$fill-practices`、`$fill-rules` 和 `$fill-skills` 消费本文件来更新对应 artifact。
+
+本文件不是仓库事实本身的替代品。填充任何 agent-facing 文档前，仍应优先核对真实源码、清单、脚本、锁文件、CI/hook 配置和现有文档。
+
+## Project Identity
+
+- **Project name**: RuoYi / 若依
+- **Current version in repository**: 4.8.3
+- **Project purpose**: 基于 Spring Boot 的轻量级 Java 快速开发框架和后台管理系统，覆盖用户、部门、岗位、菜单、角色、字典、参数、通知公告、操作日志、登录日志、在线用户、定时任务、代码生成、系统接口、服务监控、缓存监控、在线构建器和连接池监视等后台能力。
+- **Primary audience**: 个人和企业开发者/维护者，用于搭建 Web 管理后台、网站会员中心、CMS、CRM、OA 等系统。
+- **Evidence**: `README.md`, `pom.xml`, `ruoyi-admin/src/main/resources/application.yml`
+
+## Tech Stack
+
+| Category | Detected fact | Evidence | Confidence |
+| --- | --- | --- | --- |
+| Languages / runtimes | Java 17; browser-facing UI resources are HTML/CSS/JavaScript under Spring resources. | `pom.xml`; `ruoyi-admin/src/main/resources/templates/`; `ruoyi-admin/src/main/resources/static/` | high |
+| Package managers | Maven multi-module project; no Maven wrapper was found. | `pom.xml`; `ruoyi-*/pom.xml`; absence of `mvnw` / `mvnw.cmd` in repo scan | high |
+| Frameworks / libraries | Spring Boot 4.0.6, Spring Web MVC, Thymeleaf, Apache Shiro 2.2.0 Jakarta artifacts, MyBatis Spring Boot, Druid, PageHelper, Quartz, Velocity, Springdoc/OpenAPI, Fastjson, Apache POI, Bootstrap/jQuery static UI assets. | `pom.xml`; `ruoyi-admin/pom.xml`; `ruoyi-framework/pom.xml`; `ruoyi-common/pom.xml`; `ruoyi-quartz/pom.xml`; `ruoyi-generator/pom.xml`; `ruoyi-admin/src/main/resources/application.yml` | high |
+| Build tools | Maven compiler plugin targets Java 17; Spring Boot Maven plugin repackages `ruoyi-admin`; `Makefile` exposes a harness verification wrapper. | `pom.xml`; `ruoyi-admin/pom.xml`; `Makefile` | high |
+| Database / persistence | Default application profile uses Druid with MySQL datasource `jdbc:mysql://localhost:3306/ry`; SQL assets include RuoYi and Quartz schema/data files. | `ruoyi-admin/src/main/resources/application.yml`; `ruoyi-admin/src/main/resources/application-druid.yml`; `sql/ry_20260319.sql`; `sql/quartz.sql` | high |
+| Security / access control | Shiro config, session/remember-me settings, captcha, XSS filter toggle, CSRF toggle, and Druid monitor credentials are configured in application resources. | `ruoyi-admin/src/main/resources/application.yml`; `ruoyi-admin/src/main/resources/application-druid.yml`; `ruoyi-framework/pom.xml` | high |
+| Code generation | Generator uses Velocity templates and `generator.yml`; default package is `com.ruoyi.system`, table prefix is `sys_`, and `allowOverwrite` is false. | `ruoyi-generator/pom.xml`; `ruoyi-generator/src/main/resources/generator.yml`; `ruoyi-generator/src/main/resources/vm/` | high |
+
+## Validation Entrypoints
+
+| Kind | Command | Runner / binding | Evidence |
+| --- | --- | --- | --- |
+| Setup | 未配置 | not configured | No setup script, Maven wrapper, CI, or documented install command was found during scan. |
+| Full verify | `make verify` exists, but currently records `not_configured` because no checks are configured. | local Makefile -> agent validation script | `Makefile`; `.agents/skills/code-change-verification/scripts/run_validation.py` has `CHECKS: tuple[Check, ...] = ()`. |
+| Test | 未配置 | not configured | No `src/test*` tree, CI workflow, or documented test command was found. Maven lifecycle may provide `mvn test`, but it is not bound as this repo's verified runner. |
+| Lint | 未配置 | not configured | No lint config or documented lint command was found. |
+| Format check | 未配置 | not configured | No formatter config or documented format check command was found. |
+| Type check | 未绑定 | not configured | Maven compiler plugin is configured, but no official compile/typecheck command is documented or bound in `run_validation.py`. |
+| Build | 未绑定 | not configured | `pom.xml` and `ruoyi-admin/pom.xml` configure Maven build plugins; `bin/package.bat` exists, but no cross-platform official build command is documented in current harness. |
+| Hooks / CI | 未配置 | not configured | `.github/` contains only `FUNDING.yml`; no pre-commit config found. |
+
+## Repository Map Candidates
+
+- `pom.xml`: parent Maven project `com.ruoyi:ruoyi:4.8.3`, dependency management, Java 17 compiler config, module list, and Aliyun Maven repository config.
+- `ruoyi-admin/`: Web service entry module; contains `RuoYiApplication`, web controllers, Spring resources, Thymeleaf templates, static UI assets, `application.yml`, `application-druid.yml`, MyBatis config, logging config, and Springdoc/Swagger config.
+- `ruoyi-framework/`: framework core module; contains Spring MVC/AOP/configuration, Shiro integration, datasource support, filters, interceptors, exception handling, async manager, and web services.
+- `ruoyi-system/`: system business module; contains system domain objects, services, mappers, and MyBatis XML mappings for users, roles, menus, departments, dictionaries, config, notices, logs, sessions, posts, and related joins.
+- `ruoyi-common/`: shared utilities, constants, annotations, core domain/page/session objects, exceptions, config helpers, XSS support, JSON, Excel/POI utilities, HTTP helpers, and common enums.
+- `ruoyi-quartz/`: scheduled job module; contains Quartz domain/services/mappers/controllers/config, task utilities, templates, and MyBatis XML mappings.
+- `ruoyi-generator/`: code generation module; contains generator controllers/services/domain/mappers, Velocity utilities, generator config, `generator.yml`, HTML templates, and `vm/` templates for Java, XML, SQL, JS, and HTML generated output.
+- `sql/`: database assets, including `ry_20260319.sql`, `quartz.sql`, `ruoyi.pdm`, and `ruoyi.html`.
+- `bin/`, `ry.sh`, `ry.bat`: packaging, clean, run, and process control scripts.
+- `doc/`: user/operator documentation; currently contains `若依环境使用手册.docx`.
+- `docs/practices/`: agent-facing coding, product sense, security, and reliability judgment guidance.
+- `.agents/skills/`: local generated agent skills for scan/fill harness workflows, implementation strategy, PR summaries, and code-change verification.
+- `.harnesskit/`: harness config, facts, rule details, and validation receipts.
+- Test directories: no source test directories were found in the current scan.
+
+## Agent-Facing Assets
+
+| Asset | Status | Evidence / notes |
+| --- | --- | --- |
+| `AGENTS.md` | exists, filled | Contains RuoYi-specific contributor guide/routing, operation facts, validation status, skill routing, and drift handling. |
+| `CLAUDE.md` | exists as symlink to `AGENTS.md` | `CLAUDE.md -> AGENTS.md`. |
+| `ARCHITECTURE.md` | exists, filled | Contains RuoYi-specific module map, key files, generated assets, external state, and boundary notes. |
+| `RULES.md` | exists, filled | Contains RuoYi-specific rule index; every rule links to a details file under `.harnesskit/rules/`. |
+| `.harnesskit/facts.md` | exists and refreshed by `$scan-facts` | This file. |
+| `.harnesskit/config.json` | exists | Schema version 1; project name `RuoYi`; default and installed integration `codex`; harnesskit version `0.1.1`. |
+| `.harnesskit/rules/` | exists, filled | Rule detail files exist for current `RULES.md` entries and include evidence plus runner status. |
+| `docs/practices/` | exists, filled | `CODING.md`, `PRODUCT_SENSE.md`, `SECURITY.md`, `RELIABILITY.md` contain RuoYi-specific guidance. |
+| `.agents/skills/` | exists, project sections filled where evidence exists | `code-change-verification`, `implementation-strategy`, and `pr-draft-summary` have RuoYi-specific sections; generic fill/scan workflow instructions retain their reusable protocol language. |
+| Validation receipt path | configured but checks empty | `make verify` writes `.harnesskit/receipts/latest.json` and `.harnesskit/receipts/runs/<run_id>.json` after `CHECKS` are configured or to report `not_configured`. |
+
+## Rule / Guard Candidates
+
+- Build/runtime stack candidate: Java 17 + Maven multi-module + Spring Boot 4.x should be treated as the primary stack unless future repo evidence changes it. Evidence: `pom.xml`.
+- Validation candidate: `make verify` is the intended harness wrapper, but it is not usable as a successful full verification gate until `.agents/skills/code-change-verification/scripts/run_validation.py` has repository-confirmed checks. Evidence: `Makefile`, `run_validation.py`.
+- Dependency candidate: Maven dependency versions are centralized in parent `pom.xml`; no lockfile was found. Evidence: `pom.xml`, module `pom.xml` files.
+- User-visible boundary candidate: changes under controllers, templates, static resources, application YAML, SQL files, MyBatis mapper XML, generator templates/config, and startup/package scripts can affect runtime behavior, generated output, persistent config, or deployment behavior. Evidence: module layout and resource/config files.
+- Generator safety candidate: `ruoyi-generator/src/main/resources/generator.yml` has `allowOverwrite: false`; changes to generator templates or overwrite behavior should be treated as user-visible generated output behavior. Evidence: `generator.yml`, `ruoyi-generator/src/main/resources/vm/`.
+- Persistence/security candidate: SQL scripts, datasource configuration, Shiro/session/remember-me/captcha, XSS and CSRF settings, and Druid monitor config should be handled as high-impact configuration/security boundaries. Evidence: `sql/`, `application.yml`, `application-druid.yml`.
+- Context drift candidate: `AGENTS.md`, `ARCHITECTURE.md`, `RULES.md`, `docs/practices/`, and verification skill content still contain placeholders and should be filled from this facts snapshot plus direct repo evidence.
+
+## Open Questions
+
+- Which Maven command should be considered the official local build or validation runner: `mvn test`, `mvn package`, `mvn clean package`, a module-specific command, or another team-defined command?
+- Should `make verify` be configured to run Maven compile/test/package checks, and if so which checks are required vs optional?
+- Are there expected tests outside conventional `src/test*` paths, or is the current repository intentionally distributed without tests?
+- Are `bin/package.bat`, `bin/run.bat`, `ry.bat`, and `ry.sh` officially maintained release/ops entrypoints or legacy helper scripts?
+- Should database scripts in `sql/` be treated as canonical schema/migration state, and what compatibility policy applies when changing them?
+- Should demo functionality (`demoEnabled: true`) remain enabled by default in this repository, or is that only for sample deployments?

--- a/.harnesskit/rules/RULE-AI-001.md
+++ b/.harnesskit/rules/RULE-AI-001.md
@@ -1,0 +1,23 @@
+# RULE-AI-001
+
+## Rule
+
+高影响判断必须回到源码、配置、脚本、清单或现有文档核对，不能只依赖 `.harnesskit/facts.md`。
+
+## Details
+
+`.harnesskit/facts.md` 是 scan/fill 的事实快照，不是仓库事实本身的替代品。涉及 runtime behavior、配置、数据库、生成输出、验证入口、模块依赖或安全边界时，必须核对真实文件。
+
+证据：
+
+- `.harnesskit/facts.md`
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+- `pom.xml`
+- `ruoyi-admin/src/main/resources/application.yml`
+- `ruoyi-admin/src/main/resources/application-druid.yml`
+
+验证 / runner：
+
+- Runner：review / agent workflow。
+- 自动检查：未配置。

--- a/.harnesskit/rules/RULE-AI-002.md
+++ b/.harnesskit/rules/RULE-AI-002.md
@@ -1,0 +1,21 @@
+# RULE-AI-002
+
+## Rule
+
+不要把模板示例、设计愿景、旧文档或未验证 facts 当成当前实现事实。
+
+## Details
+
+当前实现事实应从源码、配置、脚本、Maven 清单、CI/hook 和已确认文档交叉验证。README 中的上游演示、文档站、多版本分支等背景不能自动转化为当前本地仓库的部署、CI、release 或 validation 能力。
+
+证据：
+
+- `README.md`
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+- `.harnesskit/facts.md`
+
+验证 / runner：
+
+- Runner：review / drift check。
+- 自动检查：未配置。

--- a/.harnesskit/rules/RULE-AI-003.md
+++ b/.harnesskit/rules/RULE-AI-003.md
@@ -1,0 +1,22 @@
+# RULE-AI-003
+
+## Rule
+
+发现代码、文档、rules、skills 或验证入口冲突时，先核对仓库事实再同步 context。
+
+## Details
+
+不要静默选择其中一边。先找可验证来源，再更新误导 agent 的 context 文件、facts、skills 或规则细节。当前 harness artifacts 由 `scan-facts` 和各 `fill-*` skills 维护；职责分层见 `AGENTS.md`。
+
+证据：
+
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+- `RULES.md`
+- `.harnesskit/facts.md`
+- `.agents/skills/`
+
+验证 / runner：
+
+- Runner：review / harness consistency check。
+- 自动检查：未配置。

--- a/.harnesskit/rules/RULE-AI-004.md
+++ b/.harnesskit/rules/RULE-AI-004.md
@@ -1,0 +1,20 @@
+# RULE-AI-004
+
+## Rule
+
+未经用户明确要求，不要重排、合并、删除已有客户手写规则。
+
+## Details
+
+已有规则是用户资产。fill skills 可以补占位符、追加缺失规则或标记待确认；重构现有规则结构必须先获得明确授权。本轮 `$fill-rules` 保留了既有 rule ID 结构，并只用仓库证据填充内容。
+
+证据：
+
+- `RULES.md`
+- `.harnesskit/rules/`
+- `.agents/skills/fill-rules/SKILL.md`
+
+验证 / runner：
+
+- Runner：review。
+- 自动检查：未配置。

--- a/.harnesskit/rules/RULE-ARCH-001.md
+++ b/.harnesskit/rules/RULE-ARCH-001.md
@@ -1,0 +1,24 @@
+# RULE-ARCH-001
+
+## Rule
+
+修改配置、SQL、MyBatis mapper、模板、生成器或运行脚本时，按用户可见或持久化边界处理。
+
+## Details
+
+这些文件会影响运行时行为、数据库状态、数据访问、页面输出、生成输出或部署/运行方式。不要把它们当作普通内部 helper 改动处理；改动前应按 `$implementation-strategy` 判断兼容性和外部影响。
+
+证据：
+
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+- `ruoyi-admin/src/main/resources/application.yml`
+- `ruoyi-admin/src/main/resources/application-druid.yml`
+- `sql/`
+- `ruoyi-system/src/main/resources/mapper/`
+- `ruoyi-generator/src/main/resources/vm/`
+- `bin/`, `ry.sh`, `ry.bat`
+
+验证 / runner：
+
+- Runner：review；自动 schema/test/build runner 未配置。

--- a/.harnesskit/rules/RULE-ARCH-002.md
+++ b/.harnesskit/rules/RULE-ARCH-002.md
@@ -1,0 +1,22 @@
+# RULE-ARCH-002
+
+## Rule
+
+`ruoyi-generator` 模板/config 和 Web/Quartz 页面资源属于用户可见输出，不能当作内部实现细节处理。
+
+## Details
+
+`ruoyi-generator/src/main/resources/vm/` 是代码生成模板，`generator.yml` 控制生成配置和覆盖行为。`ruoyi-admin/src/main/resources/templates/`、`ruoyi-admin/src/main/resources/static/` 和 `ruoyi-quartz/src/main/resources/templates/` 是运行时页面/静态资源。修改这些位置会改变用户看到的页面或生成结果。
+
+证据：
+
+- `ARCHITECTURE.md`
+- `ruoyi-generator/src/main/resources/generator.yml`
+- `ruoyi-generator/src/main/resources/vm/`
+- `ruoyi-admin/src/main/resources/templates/`
+- `ruoyi-admin/src/main/resources/static/`
+- `ruoyi-quartz/src/main/resources/templates/`
+
+验证 / runner：
+
+- Runner：review；template/generation tests 未配置。

--- a/.harnesskit/rules/RULE-ARCH-003.md
+++ b/.harnesskit/rules/RULE-ARCH-003.md
@@ -1,0 +1,19 @@
+# RULE-ARCH-003
+
+## Rule
+
+`ruoyi-admin/src/main/resources/templates/demo/` 位于运行时资源树内，不要把它当成测试 fixture 或可随意删除的样例。
+
+## Details
+
+虽然目录名是 `demo`，但它在 `ruoyi-admin/src/main/resources/templates/` 下，会随应用资源参与运行时页面展示。删除、移动或改写这些页面应按用户可见资源变更处理。
+
+证据：
+
+- `ARCHITECTURE.md`
+- `ruoyi-admin/src/main/resources/templates/demo/`
+- `ruoyi-admin/src/main/resources/application.yml` 中 `ruoyi.demoEnabled: true`
+
+验证 / runner：
+
+- Runner：review；UI/browser test runner 未配置。

--- a/.harnesskit/rules/RULE-DOMAIN-001.md
+++ b/.harnesskit/rules/RULE-DOMAIN-001.md
@@ -1,0 +1,23 @@
+# RULE-DOMAIN-001
+
+## Rule
+
+用户、角色、菜单、部门、字典、参数、日志、在线用户、定时任务和代码生成属于后台管理核心领域，不能作为无关重构顺手改变。
+
+## Details
+
+README 将这些能力列为 RuoYi 内置功能；仓库中对应 controller、service、mapper、template、SQL 和 generator 资源分布在 `ruoyi-admin`、`ruoyi-system`、`ruoyi-quartz`、`ruoyi-generator` 和 `sql/`。修改这些领域行为时需要明确任务目的、兼容性边界和验证缺口。
+
+证据：
+
+- `README.md`
+- `ARCHITECTURE.md`
+- `ruoyi-admin/src/main/java/com/ruoyi/web/controller/`
+- `ruoyi-system/`
+- `ruoyi-quartz/`
+- `ruoyi-generator/`
+- `sql/`
+
+验证 / runner：
+
+- Runner：review；domain tests 未配置。

--- a/.harnesskit/rules/RULE-ENG-001.md
+++ b/.harnesskit/rules/RULE-ENG-001.md
@@ -1,0 +1,21 @@
+# RULE-ENG-001
+
+## Rule
+
+用户可见行为变更不能声称已有自动测试覆盖，除非新增或运行了仓库确认的测试/验证。
+
+## Details
+
+RuoYi 的用户可见行为包括 Web controllers、Thymeleaf 页面、static UI assets、application YAML、SQL scripts、MyBatis mapper XML、generator templates/config 和运行/打包脚本。当前扫描没有发现 `src/test*` 测试目录、CI workflow 或文档化 test command，因此不能把“测试已覆盖”作为默认完成声明。
+
+证据：
+
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+- `.harnesskit/facts.md`
+- 当前仓库未发现 `src/test*` 测试目录。
+
+验证 / runner：
+
+- 自动测试 runner：未配置。
+- 适用检查：review；如任务新增了仓库确认的测试或验证命令，最终说明必须区分已运行检查和未配置检查。

--- a/.harnesskit/rules/RULE-ENG-002.md
+++ b/.harnesskit/rules/RULE-ENG-002.md
@@ -1,0 +1,25 @@
+# RULE-ENG-002
+
+## Rule
+
+Maven 依赖、模块或插件变更必须同步对应 `pom.xml`，不要假设存在锁文件或 Maven wrapper。
+
+## Details
+
+本仓库是 Maven multi-module 项目。父级 `pom.xml` 管理模块列表、Java 17 compiler config 和主要 dependency versions；各 `ruoyi-*/pom.xml` 声明模块职责和模块依赖。扫描没有发现 `mvnw`、`mvnw.cmd` 或 Maven lockfile。
+
+证据：
+
+- `pom.xml`
+- `ruoyi-admin/pom.xml`
+- `ruoyi-framework/pom.xml`
+- `ruoyi-system/pom.xml`
+- `ruoyi-common/pom.xml`
+- `ruoyi-quartz/pom.xml`
+- `ruoyi-generator/pom.xml`
+- `.harnesskit/facts.md`
+
+验证 / runner：
+
+- Maven build runner：未绑定为官方 gate。
+- 适用检查：review `pom.xml` diff；如果未来配置 `make verify` checks，再同步更新本 rule detail。

--- a/.harnesskit/rules/RULE-ENG-003.md
+++ b/.harnesskit/rules/RULE-ENG-003.md
@@ -1,0 +1,22 @@
+# RULE-ENG-003
+
+## Rule
+
+在验证 checks 配置前，不要把 `make verify` 当作已通过的完整验证 gate。
+
+## Details
+
+`Makefile` 提供 `verify` target，但它只调用 `.agents/skills/code-change-verification/scripts/run_validation.py`。该脚本当前 `CHECKS` 为空，运行时会写 validation receipt 并以 `not_configured` 非零退出。`make verify` 的存在说明有 harness wrapper，不说明已有完整验证栈。
+
+证据：
+
+- `Makefile`
+- `.agents/skills/code-change-verification/scripts/run_validation.py`
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+
+验证 / runner：
+
+- Runner：`make verify`
+- 当前状态：not configured，因为 `CHECKS: tuple[Check, ...] = ()`。
+- 只有当 `CHECKS` 被仓库事实填充并成功运行后，才能把它报告为 passed full verification。

--- a/.harnesskit/rules/RULE-ENG-004.md
+++ b/.harnesskit/rules/RULE-ENG-004.md
@@ -1,0 +1,23 @@
+# RULE-ENG-004
+
+## Rule
+
+不要把没有仓库配置或 runner 证据的检查写成完成条件。
+
+## Details
+
+agent 只能要求真实存在的检查。未配置的 lint、format、typecheck、coverage、docs build、CI、branch protection 或平台 gate 可以记录为待确认或未配置，但不能写成完成门槛。本仓库当前未发现 lint/format config、test tree、CI workflow、pre-commit 或 configured validation checks。
+
+证据：
+
+- `.harnesskit/facts.md`
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+- `Makefile`
+- `.agents/skills/code-change-verification/scripts/run_validation.py`
+- `.github/FUNDING.yml` 是当前唯一发现的 `.github` 文件。
+
+验证 / runner：
+
+- Runner：review / harness consistency check。
+- 自动阻断：未配置。

--- a/.harnesskit/rules/RULE-PRODUCT-001.md
+++ b/.harnesskit/rules/RULE-PRODUCT-001.md
@@ -1,0 +1,21 @@
+# RULE-PRODUCT-001
+
+## Rule
+
+不要把 README 中的上游演示、文档站或多版本分支说明写成本地仓库已配置的部署、CI 或发布能力。
+
+## Details
+
+README 提供产品背景、功能列表、在线体验和上游分支说明；这些信息有助于理解 RuoYi，但不能替代本地仓库配置证据。当前本地仓库未发现 CI workflow、release gate、部署配置或已绑定官方验证命令。
+
+证据：
+
+- `README.md`
+- `.github/FUNDING.yml`
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+
+验证 / runner：
+
+- Runner：review。
+- 自动检查：未配置。

--- a/.harnesskit/rules/RULE-SEC-001.md
+++ b/.harnesskit/rules/RULE-SEC-001.md
@@ -1,0 +1,20 @@
+# RULE-SEC-001
+
+## Rule
+
+不要把 secret、token、私有凭据或机器特定敏感信息写入模板、facts、rules、报告或生成产物。
+
+## Details
+
+安全实践和 review 提示放在 [docs/practices/SECURITY.md](../../docs/practices/SECURITY.md)。这条规则只记录最小硬约束：agent-facing context 和生成资产不应携带真实敏感信息。仓库存在 datasource、Druid monitor、Shiro/session、remember-me、XSS/CSRF 等配置面；修改这些文件时尤其要避免泄漏真实凭据或机器私有路径。
+
+证据：
+
+- `ruoyi-admin/src/main/resources/application.yml`
+- `ruoyi-admin/src/main/resources/application-druid.yml`
+- `.harnesskit/facts.md`
+- `AGENTS.md`
+
+验证 / runner：
+
+- Runner：review；secret scan 未配置。

--- a/.harnesskit/rules/RULE-SEC-002.md
+++ b/.harnesskit/rules/RULE-SEC-002.md
@@ -1,0 +1,21 @@
+# RULE-SEC-002
+
+## Rule
+
+生成器覆盖行为、文件写入路径、数据源、Shiro/session、XSS/CSRF 和 Druid monitor 配置变更必须按安全边界处理。
+
+## Details
+
+`generator.yml` 当前 `allowOverwrite: false`，其覆盖策略会影响文件写入安全和用户资产。`application.yml` 和 `application-druid.yml` 包含上传路径、datasource、Druid monitor、Shiro/session/remember-me、XSS/CSRF 等安全相关配置。改动这些设置前要明确外部影响，不能作为顺手配置清理。
+
+证据：
+
+- `ruoyi-generator/src/main/resources/generator.yml`
+- `ruoyi-admin/src/main/resources/application.yml`
+- `ruoyi-admin/src/main/resources/application-druid.yml`
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+
+验证 / runner：
+
+- Runner：review；security scanner/path safety tests 未配置。

--- a/.harnesskit/rules/RULE-STACK-001.md
+++ b/.harnesskit/rules/RULE-STACK-001.md
@@ -1,0 +1,20 @@
+# RULE-STACK-001
+
+## Rule
+
+本仓库的已确认主栈是 Java 17 + Maven multi-module + Spring Boot 4.x；不要引入或要求未配置的包管理器/构建系统。
+
+## Details
+
+父级 `pom.xml` 声明 Java 17、Spring Boot 4.0.6 和 Maven modules。仓库未发现 Gradle、npm/pnpm/yarn、uv、Go、Cargo 等构建清单，也未发现 Maven wrapper。除非用户明确要求或仓库新增证据，否则不要把其他工具作为默认 runner。
+
+证据：
+
+- `pom.xml`
+- `ruoyi-*/pom.xml`
+- `.harnesskit/facts.md`
+
+验证 / runner：
+
+- Runner：review。
+- 自动检查：未配置。

--- a/.harnesskit/rules/RULE-STACK-002.md
+++ b/.harnesskit/rules/RULE-STACK-002.md
@@ -1,0 +1,21 @@
+# RULE-STACK-002
+
+## Rule
+
+当前未配置 lint、format、typecheck、test、build、hook 或 CI required gate；新增完成条件前必须先补 runner 证据。
+
+## Details
+
+存在 Maven lifecycle 不等于仓库已声明 official build/test gate。`make verify` 当前只是未配置 checks 的 harness wrapper。新增完成条件时，应先在 manifests、scripts、hooks、CI 或 verification skill 中建立可核对 runner。
+
+证据：
+
+- `Makefile`
+- `.agents/skills/code-change-verification/scripts/run_validation.py`
+- `.github/FUNDING.yml`
+- `.harnesskit/facts.md`
+
+验证 / runner：
+
+- Runner：review。
+- 自动检查：未配置。

--- a/.harnesskit/rules/RULE-STACK-003.md
+++ b/.harnesskit/rules/RULE-STACK-003.md
@@ -1,0 +1,23 @@
+# RULE-STACK-003
+
+## Rule
+
+工具链、构建、依赖或验证入口变更必须同步更新相关 harness context 和 verification skill。
+
+## Details
+
+如果变更 `pom.xml`、module `pom.xml`、`Makefile`、verification script、CI/hook 配置或新增锁文件/构建 wrapper，就会改变 agent 的操作判断。同步对象至少包括 `.harnesskit/facts.md`、`AGENTS.md`、`ARCHITECTURE.md`、`RULES.md` details，以及 `.agents/skills/code-change-verification/` 中的项目特定验证说明。
+
+证据：
+
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+- `.harnesskit/facts.md`
+- `Makefile`
+- `.agents/skills/code-change-verification/SKILL.md`
+- `.agents/skills/code-change-verification/scripts/run_validation.py`
+
+验证 / runner：
+
+- Runner：review / harness consistency check。
+- 自动检查：未配置。

--- a/.harnesskit/rules/RULE-STYLE-001.md
+++ b/.harnesskit/rules/RULE-STYLE-001.md
@@ -1,0 +1,23 @@
+# RULE-STYLE-001
+
+## Rule
+
+跨 Maven 模块移动或复用代码前，先核对对应模块职责和 `pom.xml` 依赖方向。
+
+## Details
+
+模块职责和依赖方向会影响 Spring wiring、打包结果和运行时边界。当前结构中 `ruoyi-admin` 是 Web 入口并依赖 `ruoyi-framework`、`ruoyi-quartz`、`ruoyi-generator`；`ruoyi-framework` 依赖 `ruoyi-system`；`ruoyi-system`、`ruoyi-quartz`、`ruoyi-generator` 依赖 `ruoyi-common`。不要为了局部复用把代码移动到错误模块，或新增反向依赖。
+
+证据：
+
+- `ARCHITECTURE.md`
+- `pom.xml`
+- `ruoyi-admin/pom.xml`
+- `ruoyi-framework/pom.xml`
+- `ruoyi-system/pom.xml`
+- `ruoyi-quartz/pom.xml`
+- `ruoyi-generator/pom.xml`
+
+验证 / runner：
+
+- Runner：review；Maven compile/build runner 尚未绑定为官方 gate。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# RuoYi 贡献者指南
+
+本文件是当前仓库的 agent 启动入口：保留少量会影响操作判断的事实，并把 agent 路由到规则、架构地图、skills 和验证入口。它不是项目知识库；完整目录职责放在 [ARCHITECTURE.md](ARCHITECTURE.md)，工程约束放在 [RULES.md](RULES.md)，具体任务流程放在 [.agents/skills/](.agents/skills/)，产品背景放在 [README.md](README.md) 或 `docs/`。
+
+除非已经从构建清单、锁文件、脚本、CI 配置、代码托管平台、[.harnesskit/facts.md](.harnesskit/facts.md) 或现有文档中验证，不要把模板示例、推测命令或旧说明当作仓库已支持的流程。
+
+## 操作关键事实
+
+- 本仓库是 RuoYi / 若依 `4.8.3`：Java 17 + Maven multi-module + Spring Boot 4.0.6 的后台管理系统和快速开发框架；主要模块包括 `ruoyi-admin`、`ruoyi-framework`、`ruoyi-system`、`ruoyi-common`、`ruoyi-quartz` 和 `ruoyi-generator`。
+- 用户可见和兼容性敏感边界包括 Web controllers、Thymeleaf templates、static UI assets、`application*.yml` 配置、MyBatis mapper XML、`sql/` 数据库脚本、`ruoyi-generator/src/main/resources/vm/` 生成模板、`generator.yml`、以及 `bin/`、`ry.sh`、`ry.bat` 等运行/打包脚本。
+- 默认应用配置使用 MySQL/Druid datasource、Shiro/session/remember-me/captcha、XSS/CSRF toggles 和 Springdoc/OpenAPI；这些配置变更应按外部配置或安全边界处理。
+- `ruoyi-generator/src/main/resources/generator.yml` 当前 `allowOverwrite: false`；生成器模板或覆盖行为会影响用户可见生成输出。
+- HarnessKit 当前 schema version 为 1，project name 为 `RuoYi`，default/installed integration 为 `codex`；[CLAUDE.md](CLAUDE.md) 是指向 [AGENTS.md](AGENTS.md) 的 companion guide symlink。
+
+## 上下文路由
+
+- 开始任务前先读 [RULES.md](RULES.md)，并按需查看 [.harnesskit/rules/](.harnesskit/rules/) 中对应 rule details、验证说明或证据来源。
+- 涉及路径职责、模块边界、生成资产、持久配置、数据库脚本或旧/新实现取舍时，读 [ARCHITECTURE.md](ARCHITECTURE.md)。
+- 需要产品定位、功能背景或用户文档时，读 [README.md](README.md)、`doc/` 和相关 `docs/` 文件。
+- 涉及代码风格、产品体验、安全或可靠性判断时，按需阅读 [docs/practices/](docs/practices/)；这些文件是判断指导，不替代 [RULES.md](RULES.md) 的硬约束。
+- 触发本地 skill 时，先读对应 skill 文件；当前技能目录是 [.agents/skills/](.agents/skills/)。
+- [.harnesskit/facts.md](.harnesskit/facts.md) 是 `$scan-facts` 生成的事实快照；高影响判断仍要回到真实源码、配置、脚本或文档核对。
+
+## 工作策略
+
+- 修改用户可见行为、公开 API、外部配置、持久化数据、数据库 schema、模板输出、生成资产或运行/打包脚本前，先使用 `$implementation-strategy` 明确兼容性边界。
+- 影响运行时代码、模板、测试、构建配置、锁文件、Markdown 链接或验证行为的变更，在完成前使用 `$code-change-verification`。当前 full verification runner 尚未配置成功 checks，不能把 `make verify` 的存在等同于通过完整验证。
+- 初次补全或刷新 harness context 时，按需使用 `$harness-init` 或 `$scan-facts`；刷新后再用对应 `$fill-*` skill 更新目标 artifact。
+- 刷新 [docs/practices/](docs/practices/) 判断指导时，使用 `$fill-practices`；如果发现稳定硬约束候选，再交给 `$fill-rules`。
+- 中等及以上规模的运行时代码、测试、示例、构建/测试配置或有行为影响的文档变更完成后，按 `$pr-draft-summary` 准备交付说明；纯 repo metadata 或 guidance-only 变更可跳过。
+- 发现可复用约定、规则候选、命令漂移或待确认事项时，记录到适当的 harness artifact：事实进入 [.harnesskit/facts.md](.harnesskit/facts.md)，硬约束进入 [RULES.md](RULES.md) 和 `.harnesskit/rules/`，目录职责进入 [ARCHITECTURE.md](ARCHITECTURE.md)，判断指导进入 `docs/practices/`。
+
+## 验证入口
+
+完整验证入口当前未配置为可成功运行的 gate。
+
+当前已确认的验证 runner：
+
+- `make verify` 调用 `.agents/skills/code-change-verification/scripts/run_validation.py`，并写入 `.harnesskit/receipts/latest.json` 和 `.harnesskit/receipts/runs/<run_id>.json`。
+- 该脚本当前 `CHECKS` 为空；运行时会记录 `not_configured` 并以非零状态退出。
+
+当前未配置或未证实的检查：
+
+- Setup：未发现仓库确认的 setup command。
+- Format：未发现 formatter 配置或 format check command。
+- Lint：未发现 lint 配置或 lint command。
+- Typecheck / compile：Maven compiler plugin 已配置 Java 17，但没有官方 typecheck/compile runner 绑定。
+- Tests：未发现 `src/test*` 测试目录、CI workflow 或文档化 test command。
+- Build：Maven lifecycle 可由 `pom.xml` 推断存在，但没有仓库确认的 official build runner。
+- Hooks / CI：`.github/` 当前只发现 `FUNDING.yml`，未发现 CI workflow 或 pre-commit 配置。
+
+维护验证说明时区分 Rule、Validation 和 Runner：Rule 是约束，Validation 是检查方式，Runner 是实际执行位置。没有 runner 证据的检查只能标记为人工执行、agent 执行或未绑定，不要写成完成条件。
+
+## 漂移处理
+
+如果 [AGENTS.md](AGENTS.md)、[RULES.md](RULES.md)、[ARCHITECTURE.md](ARCHITECTURE.md)、skills、验证入口、项目命令或仓库事实互相冲突，不要静默选择一边；先核对真实文件，再同步修复漂移的 context 文件。
+
+文档职责保持分离：[AGENTS.md](AGENTS.md) 讲 agent 如何开始和路由，[RULES.md](RULES.md) 讲不能破坏的约束，[ARCHITECTURE.md](ARCHITECTURE.md) 讲仓库地图，skills 讲任务流程，[docs/practices/](docs/practices/) 讲判断指导，[README.md](README.md)、`doc/` 和 `docs/` 讲产品与使用背景。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,57 @@
+# RuoYi 架构地图
+
+本文件是当前仓库的粗粒度架构地图。它帮助 agent 和贡献者在修改前找到正确的代码区域。本文件不是工作流规范、API 参考或详细设计文档。
+
+路径说明来自真实目录结构、Maven 清单、资源配置、脚本和现有文档。更细的事实快照见 [.harnesskit/facts.md](.harnesskit/facts.md)；操作入口见 [AGENTS.md](AGENTS.md)；硬约束见 [RULES.md](RULES.md)。
+
+## 顶层地图
+
+- [pom.xml](pom.xml)：父级 Maven project `com.ruoyi:ruoyi:4.8.3`；集中管理 Java 17、Spring Boot 4.0.6、Shiro、MyBatis、Druid、Quartz、Velocity、Springdoc 等版本，并声明所有业务模块。
+- [ruoyi-admin/](ruoyi-admin/)：Web 服务入口模块，打包为 `ruoyi-admin`；包含启动类、Servlet initializer、Web controllers、Spring 配置资源、Thymeleaf 页面、静态 UI assets、MyBatis/日志配置和 application YAML。
+- [ruoyi-framework/](ruoyi-framework/)：框架核心模块；承载 Spring MVC/AOP 配置、Shiro 集成、数据源、过滤器、拦截器、异常处理、异步管理和运行时 Web support。
+- [ruoyi-system/](ruoyi-system/)：系统业务模块；承载用户、角色、菜单、部门、字典、参数、通知、日志、在线用户、岗位等 system domain/service/mapper 和 MyBatis XML。
+- [ruoyi-common/](ruoyi-common/)：通用基础模块；承载常量、注解、公共 domain/page/session 类型、异常、配置 helper、XSS support、JSON、Excel/POI、HTTP、枚举和工具类。
+- [ruoyi-quartz/](ruoyi-quartz/)：定时任务模块；承载 Quartz job domain/service/mapper/controller/config、任务工具、job 页面模板和 mapper XML。
+- [ruoyi-generator/](ruoyi-generator/)：代码生成模块；承载生成器 controller/service/domain/mapper、Velocity utilities、生成配置、生成器页面和生成输出模板。
+- [sql/](sql/)：数据库资产，包括 RuoYi schema/data、Quartz SQL、PDM 模型和 HTML 数据库说明。
+- [bin/](bin/)、[ry.sh](ry.sh)、[ry.bat](ry.bat)：Windows/Linux 清理、打包、运行和进程控制脚本。
+- [doc/](doc/)：用户或环境说明文档，目前包含 `若依环境使用手册.docx`。
+- [docs/practices/](docs/practices/)：agent-facing 代码、产品、安全、可靠性判断指导；不替代 [RULES.md](RULES.md) 的硬约束。
+- [.agents/skills/](.agents/skills/)：本地 generated agent skills；任务流程放在各 skill 文件中。
+- [.harnesskit/](.harnesskit/)：HarnessKit 状态、facts、rule details 和 validation receipts。
+- [.github/](.github/)：当前只发现 `FUNDING.yml`；没有 CI workflow 证据。
+
+## 关键文件
+
+- [AGENTS.md](AGENTS.md)：agent 操作入口和顶层路由器。
+- [CLAUDE.md](CLAUDE.md)：companion agent 指南 symlink，当前指向 [AGENTS.md](AGENTS.md)。
+- [RULES.md](RULES.md)：规则索引；details 位于 [.harnesskit/rules/](.harnesskit/rules/)。
+- [.harnesskit/facts.md](.harnesskit/facts.md)：`$scan-facts` 生成的 scan/fill 事实快照。
+- [Makefile](Makefile)：HarnessKit 验证入口 wrapper；调用 `.agents/skills/code-change-verification/scripts/run_validation.py`。
+- [.agents/skills/code-change-verification/scripts/run_validation.py](.agents/skills/code-change-verification/scripts/run_validation.py)：验证 receipt runner；当前 `CHECKS` 为空，运行会报告 `not_configured`。
+- [ruoyi-admin/src/main/java/com/ruoyi/RuoYiApplication.java](ruoyi-admin/src/main/java/com/ruoyi/RuoYiApplication.java)：Spring Boot 应用启动类。
+- [ruoyi-admin/src/main/resources/application.yml](ruoyi-admin/src/main/resources/application.yml)：应用主配置，包含 RuoYi metadata、server、Thymeleaf、MyBatis、Shiro、Springdoc、XSS/CSRF 等配置。
+- [ruoyi-admin/src/main/resources/application-druid.yml](ruoyi-admin/src/main/resources/application-druid.yml)：Druid/MySQL datasource 和 Druid monitor 配置。
+- [ruoyi-generator/src/main/resources/generator.yml](ruoyi-generator/src/main/resources/generator.yml)：代码生成配置；默认 package 为 `com.ruoyi.system`，table prefix 为 `sys_`，`allowOverwrite: false`。
+- [README.md](README.md)：项目定位、功能列表、版本分支和演示信息。
+
+## 生成资产和外部状态
+
+- 代码生成入口位于 [ruoyi-generator/](ruoyi-generator/)；生成源模板集中在 [ruoyi-generator/src/main/resources/vm/](ruoyi-generator/src/main/resources/vm/)（Java、HTML、XML、SQL 等），生成器页面位于 [ruoyi-generator/src/main/resources/templates/](ruoyi-generator/src/main/resources/templates/)。
+- Web 页面和前端静态资源是运行时用户可见资产：主要位于 [ruoyi-admin/src/main/resources/templates/](ruoyi-admin/src/main/resources/templates/) 和 [ruoyi-admin/src/main/resources/static/](ruoyi-admin/src/main/resources/static/)；Quartz job 页面位于 [ruoyi-quartz/src/main/resources/templates/](ruoyi-quartz/src/main/resources/templates/)。
+- MyBatis SQL mapping 是运行时数据访问边界：system mappings 在 [ruoyi-system/src/main/resources/mapper/](ruoyi-system/src/main/resources/mapper/)，Quartz mappings 在 [ruoyi-quartz/src/main/resources/mapper/](ruoyi-quartz/src/main/resources/mapper/)，generator mappings 在 [ruoyi-generator/src/main/resources/mapper/](ruoyi-generator/src/main/resources/mapper/)。
+- 持久化和外部状态主要由 [sql/](sql/)、[application.yml](ruoyi-admin/src/main/resources/application.yml)、[application-druid.yml](ruoyi-admin/src/main/resources/application-druid.yml) 和 MyBatis mapper XML 定义。变更这些文件时要按数据库 schema、外部配置或安全边界处理。
+- 发布/运行产物由 Maven build 配置和脚本约定影响：`ruoyi-admin/pom.xml` 使用 Spring Boot Maven plugin repackage，`ry.sh` 期望运行 `ruoyi-admin.jar`。官方 build runner 尚未在 harness 中确认。
+
+## 边界说明
+
+- Maven module boundaries matter：`ruoyi-admin` 依赖 `ruoyi-framework`、`ruoyi-quartz` 和 `ruoyi-generator`；`ruoyi-framework` 依赖 `ruoyi-system`；`ruoyi-system`、`ruoyi-quartz` 和 `ruoyi-generator` 依赖 `ruoyi-common`。跨模块改动前先核对对应 `pom.xml`。
+- `ruoyi-admin/src/main/resources/templates/demo/` 是演示页面资源，但仍在运行时资源树内；删除或改动前不要把它当成测试 fixture。
+- 当前扫描未发现 `src/test*` 测试目录、CI workflow、pre-commit、lint config 或 formatter config。不要把未绑定检查写成完成条件。
+- `make verify` 是 harness wrapper，不是已配置完整验证 gate；在 `run_validation.py` 的 `CHECKS` 补全前会返回 `not_configured`。
+- README 提到线上演示、文档地址和多版本分支信息；这些是产品/上游背景，不等于当前本地仓库已配置的部署、CI 或发布流程。
+- `sql/` 脚本看起来是 schema/data 资产，但当前没有迁移工具或 schema version runner 证据；数据库兼容策略需要在修改前单独确认或记录。
+
+## 更新规则
+
+当主要模块、关键配置、数据库资产、生成模板、运行/打包脚本、验证入口或 agent-facing harness 文件发生变化时，同步更新本地图。只有当新路径会改变 agent 首先应该查看的位置时，才把它加入这里；不要因为每个 helper 或页面文件移动就扩展成本文件清单。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: verify
+
+PYTHON ?= python3
+
+verify:
+	$(PYTHON) .agents/skills/code-change-verification/scripts/run_validation.py

--- a/RULES.md
+++ b/RULES.md
@@ -1,0 +1,52 @@
+# RuoYi Harness Rules
+
+本文件是 agent 约束索引。Rule 不是 workflow，也不是通用工程建议；Rule 只记录这个仓库里永远或局部必须成立的约束。
+
+Skills 教 agent 怎么做一类任务；Rules 告诉 agent 在这个仓库里必须遵守什么；validation 负责把可检查的约束变成可执行反馈。[AGENTS.md](AGENTS.md) 负责路由，`.agents/skills/` 负责流程，[RULES.md](RULES.md) 只保留短约束句，不负责决定该调用哪个 skill。
+
+每条规则必须有对应 details 文件，放在 [.harnesskit/rules/](.harnesskit/rules/)。[RULES.md](RULES.md) 负责告诉 agent “什么不能破坏”，details 文件负责说明“为什么、证据是什么、如何验证”。
+
+除非已经从构建清单、锁文件、脚本、CI 配置、代码托管平台、[.harnesskit/facts.md](.harnesskit/facts.md) 或现有文档中验证，不要把模板示例当作仓库已支持的命令或流程。
+
+## 通用工程实践
+
+- RULE-ENG-001: 用户可见行为变更不能声称已有自动测试覆盖，除非新增或运行了仓库确认的测试/验证。([details](.harnesskit/rules/RULE-ENG-001.md))
+- RULE-ENG-002: Maven 依赖、模块或插件变更必须同步对应 `pom.xml`，不要假设存在锁文件或 Maven wrapper。([details](.harnesskit/rules/RULE-ENG-002.md))
+- RULE-ENG-003: 在验证 checks 配置前，不要把 `make verify` 当作已通过的完整验证 gate。([details](.harnesskit/rules/RULE-ENG-003.md))
+- RULE-ENG-004: 不要把没有仓库配置或 runner 证据的检查写成完成条件。([details](.harnesskit/rules/RULE-ENG-004.md))
+
+## 代码风格与维护性
+
+- RULE-STYLE-001: 跨 Maven 模块移动或复用代码前，先核对对应模块职责和 `pom.xml` 依赖方向。([details](.harnesskit/rules/RULE-STYLE-001.md))
+
+## AI Coding 规则
+
+- RULE-AI-001: 高影响判断必须回到源码、配置、脚本、清单或现有文档核对，不能只依赖 `.harnesskit/facts.md`。([details](.harnesskit/rules/RULE-AI-001.md))
+- RULE-AI-002: 不要把模板示例、设计愿景、旧文档或未验证 facts 当成当前实现事实。([details](.harnesskit/rules/RULE-AI-002.md))
+- RULE-AI-003: 发现代码、文档、rules、skills 或验证入口冲突时，先核对仓库事实再同步 context。([details](.harnesskit/rules/RULE-AI-003.md))
+- RULE-AI-004: 未经用户明确要求，不要重排、合并、删除已有客户手写规则。([details](.harnesskit/rules/RULE-AI-004.md))
+
+## 技术栈规则
+
+- RULE-STACK-001: 本仓库的已确认主栈是 Java 17 + Maven multi-module + Spring Boot 4.x；不要引入或要求未配置的包管理器/构建系统。([details](.harnesskit/rules/RULE-STACK-001.md))
+- RULE-STACK-002: 当前未配置 lint、format、typecheck、test、build、hook 或 CI required gate；新增完成条件前必须先补 runner 证据。([details](.harnesskit/rules/RULE-STACK-002.md))
+- RULE-STACK-003: 工具链、构建、依赖或验证入口变更必须同步更新相关 harness context 和 verification skill。([details](.harnesskit/rules/RULE-STACK-003.md))
+
+## 架构规则
+
+- RULE-ARCH-001: 修改配置、SQL、MyBatis mapper、模板、生成器或运行脚本时，按用户可见或持久化边界处理。([details](.harnesskit/rules/RULE-ARCH-001.md))
+- RULE-ARCH-002: `ruoyi-generator` 模板/config 和 Web/Quartz 页面资源属于用户可见输出，不能当作内部实现细节处理。([details](.harnesskit/rules/RULE-ARCH-002.md))
+- RULE-ARCH-003: `ruoyi-admin/src/main/resources/templates/demo/` 位于运行时资源树内，不要把它当成测试 fixture 或可随意删除的样例。([details](.harnesskit/rules/RULE-ARCH-003.md))
+
+## 产品与体验规则
+
+- RULE-PRODUCT-001: 不要把 README 中的上游演示、文档站或多版本分支说明写成本地仓库已配置的部署、CI 或发布能力。([details](.harnesskit/rules/RULE-PRODUCT-001.md))
+
+## 安全规则
+
+- RULE-SEC-001: 不要把 secret、token、私有凭据或机器特定敏感信息写入模板、facts、rules、报告或生成产物。([details](.harnesskit/rules/RULE-SEC-001.md))
+- RULE-SEC-002: 生成器覆盖行为、文件写入路径、数据源、Shiro/session、XSS/CSRF 和 Druid monitor 配置变更必须按安全边界处理。([details](.harnesskit/rules/RULE-SEC-002.md))
+
+## 产品 / 领域规则
+
+- RULE-DOMAIN-001: 用户、角色、菜单、部门、字典、参数、日志、在线用户、定时任务和代码生成属于后台管理核心领域，不能作为无关重构顺手改变。([details](.harnesskit/rules/RULE-DOMAIN-001.md))

--- a/docs/practices/CODING.md
+++ b/docs/practices/CODING.md
@@ -1,0 +1,39 @@
+# Coding Practices
+
+本文件记录当前仓库的代码判断指导。它不是硬规则索引；必须遵守的约束仍以 [RULES.md](../../RULES.md) 和 `.harnesskit/rules/` 为准。
+
+## 判断原则
+
+- 先按 Maven 模块职责定位改动：Web 入口和页面在 `ruoyi-admin`，框架集成在 `ruoyi-framework`，系统业务在 `ruoyi-system`，公共类型和工具在 `ruoyi-common`，定时任务在 `ruoyi-quartz`，代码生成在 `ruoyi-generator`。
+- 跨模块复用前先核对 `pom.xml` 依赖方向。不要为了局部方便把业务逻辑下沉到 `ruoyi-common`，也不要引入反向依赖。
+- 优先做贴近现有 Spring MVC / MyBatis / Thymeleaf / Shiro 写法的小改动。只有当抽象能减少真实重复、清楚职责或降低跨模块耦合时才新增抽象。
+- 修改 controllers、templates、static resources、mapper XML、SQL、application YAML、generator templates 或 scripts 时，把它们当成用户可见或持久化边界，不混入无关格式化和顺手重构。
+- 当前没有 formatter 或 lint runner 证据；编辑时尽量保持邻近代码风格，避免大面积 whitespace churn。
+
+## Do
+
+- 读相邻 controller/service/mapper/template 的现有模式，再决定放置位置和命名。
+- 保持 Java package 与模块语义一致，例如 `com.ruoyi.system`、`com.ruoyi.quartz`、`com.ruoyi.generator`、`com.ruoyi.common`。
+- 修改 MyBatis mapper XML 时同步核对对应 mapper interface、domain/service 调用和 SQL scripts 是否受影响。
+- 修改页面模板或 static assets 时核对对应 controller route、权限、菜单和运行时资源边界。
+- 对生成器改动同时核对 `generator.yml`、`vm/` templates、生成器页面和生成输出语义。
+
+## Don't
+
+- 不要把 `templates/demo/` 当成测试 fixture；它位于运行时资源树内。
+- 不要把 README 的上游说明、示例命令或演示站点当成当前仓库的本地实现事实。
+- 不要新增未配置工具链、格式化器、package manager 或验证命令作为完成条件。
+- 不要因为缺少测试目录就跳过风险说明；要明确哪些检查未配置、哪些只做了 review。
+
+## Review Questions
+
+- 这个改动是否保持在正确的 Maven 模块和 package 边界里？
+- 新依赖或代码移动是否改变了 `pom.xml` 依赖方向？
+- 是否触及 Web 页面、静态资源、配置、SQL、mapper XML、generator templates 或运行脚本？
+- 新抽象是否降低复杂度，还是只是移动代码？
+- 是否混入无关重排、格式 churn 或顺手重构？
+- 如果用户可见行为改变了，当前仓库是否有真实测试/验证 runner 可运行？没有的话是否如实说明？
+
+## 和 Rules 的关系
+
+违反硬约束时按 [RULES.md](../../RULES.md) 处理；本文件只帮助判断“怎样写得更像这个仓库”。发现新的稳定硬约束候选时，交给 `$fill-rules` 更新 `RULES.md` 和 `.harnesskit/rules/`。

--- a/docs/practices/PRODUCT_SENSE.md
+++ b/docs/practices/PRODUCT_SENSE.md
@@ -1,0 +1,34 @@
+# Product Sense Practices
+
+本文件记录当前仓库的产品判断和体验指导。它解释取舍，不替代 [RULES.md](../../RULES.md) 中的硬约束。
+
+## Product North Star
+
+RuoYi 是面向个人和企业开发者/维护者的 Java 后台管理系统和快速开发框架。核心用户结果是：能以稳定、可理解、可扩展的方式搭建 Web 管理后台、CMS、CRM、OA 等系统，并复用内置的权限、组织、字典、日志、定时任务、监控和代码生成能力。
+
+## Experience Principles
+
+- 后台管理体验优先清晰、稳定和可维护。表单、列表、权限、菜单、日志和监控页面应保持可预期，不追求无证据的新交互风格。
+- 生成器输出是产品体验的一部分。模板应生成可读、可维护、贴近当前模块结构的 Java/HTML/XML/SQL，而不是只满足一次性生成。
+- 配置默认值要谨慎。`application.yml`、`application-druid.yml`、Shiro/session、XSS/CSRF、Druid monitor 和上传路径会影响部署体验和安全理解。
+- 文案和 docs 只描述当前仓库能证实的能力。README 中的上游演示、文档地址和多版本分支说明不能写成本地仓库已经配置的 CI、部署或发布流程。
+- demo 页面位于运行时资源树内；调整 demo 体验时仍按用户可见页面处理。
+
+## Surface Guidance
+
+- Web UI：保持现有 Spring MVC + Thymeleaf + Bootstrap/jQuery 风格；优先修正实际页面行为、权限入口和数据展示，不引入不一致的前端架构。
+- API / controllers：用户能观察到的 URL、返回结构、权限、错误处理和导出行为都属于产品 surface；改动前核对 controller、service、mapper 和 template 的链路。
+- Generated output：修改 `ruoyi-generator/src/main/resources/vm/` 或 `generator.yml` 时，关注生成代码的可读性、模块归属、覆盖策略和与 MyBatis/Thymeleaf 当前模式的一致性。
+- Docs：`README.md` 讲产品和上游背景，`doc/` 讲使用/环境说明，`AGENTS.md` / `ARCHITECTURE.md` / `RULES.md` / `docs/practices/` 讲 agent-facing context。不要互相复制长篇内容。
+
+## Review Questions
+
+- 这个改动是否减少管理员、开发者或 agent 的猜测？
+- 用户会不会误以为未配置的 CI、测试、部署、发布或安全流程已经存在？
+- 生成器输出是否仍然像 RuoYi 当前代码，而不是引入孤立风格？
+- 页面或配置默认值是否会改变部署、安全或权限体验？
+- 错误、TODO、文档提示是否给出了真实下一步，而不是泛泛承诺？
+
+## 和 Rules 的关系
+
+产品相关硬约束见 `RULE-PRODUCT-001` 和 `RULE-DOMAIN-001`。本文件用于指导取舍；如果发现新的稳定产品不变量，应通过 `$fill-rules` 升级。

--- a/docs/practices/RELIABILITY.md
+++ b/docs/practices/RELIABILITY.md
@@ -1,0 +1,40 @@
+# Reliability Practices
+
+本文件记录当前仓库的可靠性、质量和防漂移判断指导。它不替代 [RULES.md](../../RULES.md) 的验证门槛。
+
+## Protected Boundaries
+
+- Runtime behavior：controllers、services、framework config、filters/interceptors、Shiro/session、Quartz jobs 和 MyBatis mapper XML。
+- User-visible assets：Thymeleaf templates、static UI resources、Quartz job templates、demo pages 和 Springdoc/OpenAPI exposure。
+- Persistent state：`sql/` scripts、MySQL/Druid datasource config、mapper XML 和任何影响数据库读写的 domain/service change。
+- Generated output：`ruoyi-generator/src/main/resources/vm/`、`generator.yml` 和 generator UI templates。
+- Operations surface：`bin/`, `ry.sh`, `ry.bat`, Maven packaging config and `Makefile`.
+- Agent context：`AGENTS.md`, `ARCHITECTURE.md`, `RULES.md`, `.harnesskit/facts.md`, `.harnesskit/rules/`, `.agents/skills/` and `docs/practices/`.
+
+## Guidance
+
+- 先判断改动触及哪个 protected boundary，再选择验证策略。没有 runner 证据时，只能说 review 或未配置，不能声称自动验证通过。
+- `make verify` 当前是 harness wrapper，但 `CHECKS` 为空；运行会记录 `not_configured`。不要把它当作完整 gate。
+- Maven lifecycle 可由 `pom.xml` 推断存在，但尚未被仓库声明为 official build/test runner。需要把 Maven 命令写成 gate 时，先更新 verification skill 和 rules。
+- 配置、SQL、mapper XML 和 generator templates 的改动风险通常高于普通内部 helper；最终说明要点明验证缺口。
+- 如果验证失败，修复后重跑同一个已确认的验证入口，并只报告最终状态。当前没有已配置自动入口时，报告未运行原因。
+- context 文件之间发生漂移时，回到真实文件核对，再同步 `.harnesskit/facts.md`、`AGENTS.md`、`ARCHITECTURE.md`、`RULES.md`、skills 或 practices。
+
+## Review Questions
+
+- 这次改动触及 runtime、配置、数据库、生成输出、运行脚本还是 agent context？
+- 是否需要兼容性判断、schema review、手工页面检查或生成输出 review？
+- 是否新增了 dependency、module、plugin 或 runner，需要同步 `pom.xml`、facts、rules 和 verification skill？
+- 文档、templates 和 rules 是否仍指向真实存在的命令和路径？
+- 最终回复是否区分了 passed、not configured、not run 和 review-only？
+
+## 当前验证状态
+
+- Full verification：`make verify` 存在，但当前 `run_validation.py` 的 `CHECKS` 为空，会返回 `not_configured`。
+- Tests：未发现 `src/test*` 测试目录或文档化 test command。
+- Lint / format / typecheck / CI / hook：未发现已绑定 runner。
+- Build：Maven build config 存在，但 official build runner 未在 harness 中确认。
+
+## 和 Rules 的关系
+
+完成条件和 runner 事实见 `RULE-ENG-003`、`RULE-ENG-004`、`RULE-STACK-002`。本文件提供判断流程，不新增 gate。

--- a/docs/practices/SECURITY.md
+++ b/docs/practices/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Practices
+
+本文件记录当前仓库的安全判断指导。安全硬约束仍应抽到 [RULES.md](../../RULES.md) 和 `.harnesskit/rules/`，并尽可能绑定测试、lint 或 review。
+
+## Scope
+
+本仓库最重要的安全边界来自配置、权限、文件写入、生成输出和数据库访问：
+
+- `application.yml`：server、upload profile、Shiro login/session/remember-me/captcha、XSS/CSRF toggles、Springdoc exposure。
+- `application-druid.yml`：MySQL datasource、Druid monitor、数据库连接池和 wall/stat config。
+- `ruoyi-generator/src/main/resources/generator.yml`：生成 package、table prefix 和 `allowOverwrite`。
+- `ruoyi-generator/src/main/resources/vm/`：生成代码、SQL、XML 和页面输出。
+- `sql/` and MyBatis mapper XML：schema/data and runtime SQL behavior.
+- `bin/`, `ry.sh`, `ry.bat`：process control and deployment-adjacent scripts.
+
+当前没有发现 security disclosure policy、secret scan、dependency scan、CI security gate 或支持版本/SLA 证据；不要虚构这些流程。
+
+## Guidance
+
+- 不要把 secret、token、私有凭据、真实用户数据、私有 URL 或机器特定敏感信息写入模板、facts、rules、报告或生成产物。
+- 处理 datasource、Druid monitor、Shiro/session/remember-me、captcha、XSS/CSRF、upload path 或 generated file overwrite 时，先判断是否改变了部署安全默认值。
+- 修改 `generator.yml` 或 generator templates 时，关注路径、覆盖策略、SQL/XML 输出和用户手写内容是否可能被覆盖。
+- 修改 mapper XML、SQL scripts 或 dynamic SQL helper 时，关注权限过滤、数据范围、SQL 注入和多语句行为；当前没有自动 SQL/security runner，至少需要 review。
+- 修改 shell/batch scripts 时，关注命令参数、路径引用、进程匹配和日志/输出泄漏。
+- 依赖升级或新增依赖应回到 `pom.xml` 和模块 `pom.xml` 核对，不要引入未说明来源的 binary/vendor 内容。
+
+## Review Questions
+
+- 输出里是否可能包含真实 secret、token、私有 URL、用户名、密码或机器路径？
+- 配置默认值是否扩大了登录、session、Druid monitor、Swagger/OpenAPI、XSS 或 CSRF 暴露面？
+- 文件写入或生成输出是否可能覆盖用户手写内容、写到项目外，或生成危险 SQL/XML/HTML？
+- Mapper、SQL 或 data scope 改动是否绕过权限、部门/角色过滤或审计日志？
+- 安全声明是否有仓库证据，还是只是通用最佳实践？
+- 如果没有自动安全检查，最终说明是否明确为 review-only / not configured？
+
+## 和 Rules 的关系
+
+硬约束见 `RULE-SEC-001` 和 `RULE-SEC-002`。本文件提供安全 review 角度；如果新增真实 scanner、policy 或 disclosure workflow，应同步 `$fill-rules`、`$fill-agents` 和 `$fill-skills`。


### PR DESCRIPTION
## Summary
- add AGENTS, ARCHITECTURE, RULES, and HarnessKit facts/rule details for RuoYi
- add generated local agent skills and practices guidance
- document current verification status as not configured instead of inventing checks

## Verification
- Not run: guidance-only/context changes; repository full verification runner is currently not configured.